### PR TITLE
Remove "atop" from list of dependencies

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -59,8 +59,7 @@ DEPENDS += ubuntu-dbgsym-keyring,
 # product should not rely on them programmatically. They may be updated
 # or replaced without regard for backward compatibility.
 #
-DEPENDS += atop, \
-	   bpfcc-tools, \
+DEPENDS += bpfcc-tools, \
 	   crash, \
 	   dnsutils, \
 	   dstat, \


### PR DESCRIPTION
During upgrade verification which runs in a systemd-nspawn container,
the "atop" package may fail due to the following error:

    Setting up atop (2.3.0-1) ...
    Created symlink /etc/systemd/system/multi-user.target.wants/atop.service → /lib/systemd/system/atop.service.
    Created symlink /etc/systemd/system/multi-user.target.wants/atopacct.service → /lib/systemd/system/atopacct.service.
    Job for atopacct.service failed because a timeout was exceeded.
    See "systemctl status atopacct.service" and "journalctl -xe" for details.
    invoke-rc.d: initscript atopacct, action "start" failed.
    ● atopacct.service - Atop process accounting daemon
       Loaded: loaded (/lib/systemd/system/atopacct.service; enabled; vendor preset: enabled)
       Active: failed (Result: timeout) since Fri 2018-10-19 19:34:53 UTC; 9ms ago
         Docs: man:atopacctd(8)
      Process: 7827 ExecStart=/usr/sbin/atopacctd (code=exited, status=0/SUCCESS)

    Oct 19 19:33:23 ip-10-110-210-78 systemd[1]: Starting Atop process accounting daemon...
    Oct 19 19:33:23 ip-10-110-210-78 atopacctd[7827]: receive NETLINK family, errno -2
    Oct 19 19:34:53 ip-10-110-210-78 systemd[1]: atopacct.service: Start operation timed out. Terminating.
    Oct 19 19:34:53 ip-10-110-210-78 systemd[1]: atopacct.service: Failed with result 'timeout'.
    Oct 19 19:34:53 ip-10-110-210-78 systemd[1]: Failed to start Atop process accounting daemon.
    dpkg: error processing package atop (--configure):
     installed atop package post-installation script subprocess returned error exit status 1

Thus, to avoid this failure, this change simply removes the "atop"
package from the list of dependencies.