### PR TITLE
Add script + ansible logic to unpack upgrade image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ package:
 	done
 
 shellcheck:
-	shellcheck etc/delphix-platform/ansible/apply
+	shellcheck \
+		etc/delphix-platform/ansible/apply \
+		etc/delphix-platform/upgrade/unpack-image
 
 shfmtcheck:
-	! shfmt -d etc/delphix-platform/ansible/apply | grep .
+	! shfmt -d \
+		etc/delphix-platform/ansible/apply \
+		etc/delphix-platform/upgrade/unpack-image | grep .

--- a/etc/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/etc/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -40,6 +40,32 @@
     mode: 0777
 
 #
+# Create the directory and ZFS dataset that we'll use to store unpacked
+# upgrade images. This directory is used by the upgrade related scripts
+# found in this directory, but also used by upgrade-scripts stored in
+# the appliace-build repository (which generates the upgrade image).
+# Thus, we need to be careful if/when changing this, as we'll need to
+# coordinate the change with the appliance-build upgrade-scripts.
+#
+- file:
+    path: /var/dlpx-update
+    state: directory
+
+#
+# The zfs module cannot be run from the chroot environment that's used
+# by appliance-build. Thus, we disable this when run in that context by
+# only running this when ansible_is_chroot is not true.
+#
+- zfs:
+    name: rpool/update
+    state: present
+    extra_zfs_properties:
+      mountpoint: /var/dlpx-update
+      compression: gzip
+      quota: 15g
+  when: not ansible_is_chroot
+
+#
 # Configure journald to persistently keep logs, so that we can inspect
 # them after a reboot has already occurred. This helps debugging, and
 # also can make the collection of support bundles more useful.

--- a/etc/delphix-platform/ansible/apply
+++ b/etc/delphix-platform/ansible/apply
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -o pipefail
 

--- a/etc/delphix-platform/upgrade/unpack-image
+++ b/etc/delphix-platform/upgrade/unpack-image
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+UPDATE_DIR=${UPDATE_DIR:-/var/dlpx-update}
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+function usage() {
+	echo "$(basename "$0"): $*" >&2
+	echo "Usage: $(basename "$0") [-f] <image>"
+	exit 2
+}
+
+function cleanup() {
+	[[ -d "$UNPACK_DIR" ]] && rm -rf "$UNPACK_DIR"
+}
+
+opt_f=false
+while getopts ':f' c; do
+	case "$c" in
+	f) eval "opt_$c=true" ;;
+	*) usage "illegal option -- $OPTARG" ;;
+	esac
+done
+shift $((OPTIND - 1))
+
+[[ $# -gt 1 ]] && usage "too many arguments specified"
+[[ $# -eq 0 ]] && usage "too few arguments specified"
+
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+[[ -d "$UPDATE_DIR" ]] || die "$UPDATE_DIR does not exist"
+
+case "$1" in
+*.upgrade.tar.gz) ;;
+*) die "The upgrade image must be a '.upgrade.tar.gz' file" ;;
+esac
+
+trap cleanup EXIT
+UNPACK_DIR=$(mktemp -d -p "$UPDATE_DIR" -t unpack.XXXXXXX)
+[[ -d "$UNPACK_DIR" ]] || die "failed to create unpack directory"
+
+(
+	cd "$UNPACK_DIR"
+	tar -xzf -
+) <"$1" ||
+	die "failed to extract upgrade image '$1'"
+
+[[ -f "$UNPACK_DIR/version.info" ]] || die "the upgrade image is corrupt"
+
+#
+# We need to be careful when sourcing this file, since it can conflict
+# with (and clobber) functions and/or variables previously defined.
+#
+# shellcheck disable=SC1090
+. "$UNPACK_DIR/version.info"
+
+[[ -n "$VERSION" ]] || die "VERSION variable is empty"
+[[ -n "$MINIMUM_VERSION" ]] || die "MINIMUM_VERSION variable is empty"
+[[ -n "$MINIMUM_REBOOT_OPTIONAL_VERSION" ]] ||
+	die "MINIMUM_REBOOT_OPTIONAL_VERSION variable is empty"
+
+$opt_f && rm -rf "${UPDATE_DIR/$VERSION:?/}" >/dev/null 2>&1
+
+[[ -d "$UPDATE_DIR/$VERSION" ]] && die "version $VERSION already exists"
+
+mv "$UNPACK_DIR" "$UPDATE_DIR/$VERSION" ||
+	die "failed to move unpacked upgrade image to $UPDATE_DIR/$VERSION"
+
+rm -f "$UPDATE_DIR/latest" || die "failed to remove 'latest' symlink"
+ln -s "$VERSION" "$UPDATE_DIR/latest" || die "failed to create 'latest' symlink"
+
+exit 0


### PR DESCRIPTION
This change adds a script to this repository that can be used to unpack
an upgrade image, such that the upgrade-scripts contained in that image
can then be used to upgrade the appliance.