### PR TITLE
Fix "unpack-image" when "-f" option is used

### DIFF
--- a/etc/delphix-platform/upgrade/unpack-image
+++ b/etc/delphix-platform/upgrade/unpack-image
@@ -76,7 +76,7 @@ UNPACK_DIR=$(mktemp -d -p "$UPDATE_DIR" -t unpack.XXXXXXX)
 [[ -n "$MINIMUM_REBOOT_OPTIONAL_VERSION" ]] ||
 	die "MINIMUM_REBOOT_OPTIONAL_VERSION variable is empty"
 
-$opt_f && rm -rf "${UPDATE_DIR/$VERSION:?/}" >/dev/null 2>&1
+$opt_f && rm -rf "${UPDATE_DIR:?}/$VERSION" >/dev/null 2>&1
 
 [[ -d "$UPDATE_DIR/$VERSION" ]] && die "version $VERSION already exists"
 


### PR DESCRIPTION
Currently, when using the "-f" option with the "unpack-image" script,
it'll fail and simulateously clear the contents "/var/dlpx-update". This
change fixes how the $UPDATE_DIR and $VERSION variables are expanded
when executing the "rm -rf" command, resolving the issue.