### PR TITLE
Pass in the name of the root filesystem to ansible playbooks

### DIFF
--- a/etc/delphix-platform/ansible/apply
+++ b/etc/delphix-platform/ansible/apply
@@ -19,6 +19,7 @@ set -o pipefail
 
 SOURCE_DIRECTORY="$(readlink -f "${BASH_SOURCE%/*}")"
 DLPX_ANSIBLE_DIRECTORY="${DLPX_ANSIBLE_DIRECTORY:-$SOURCE_DIRECTORY}"
+ROOT_FILESYSTEM=$(zfs list -Ho name /)
 
 function find_playbooks() {
 	if ! find "$DLPX_ANSIBLE_DIRECTORY" \
@@ -34,6 +35,7 @@ function apply_playbook() {
 	if ! ansible-playbook -vvv \
 		-c "$DLPX_ANSIBLE_CONNECTION" \
 		-i "$DLPX_ANSIBLE_INVENTORY" \
+		-e "root_filesystem=${ROOT_FILESYSTEM}" \
 		"$1"; then
 		echo "Failure when applying playbook." 2>&1
 		exit 1


### PR DESCRIPTION
This change passes in the name of the root filesystem to ansible
playbooks to enable them to make modifications to root filesystem
properties without implementing root filesystem discovery logic within
ansible.

I tested this by applying this diff to an already installed apply script, and
modifying the virtualization package's ansible role to set a zfs property
on the filesystem.