### PR TITLE
Remove the ubuntu welcome banner, help info, and last login when ssh-ing

### DIFF
--- a/etc/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/etc/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -168,6 +168,20 @@
     replace: '#\1'
 
 #
+# Ssh leads to the CLI, not bash, so let's remove all the linuxy shell goodies,
+# like last-login, "welcome to ubuntu", and help messages. This makes linux and
+# illumos look the same, too.
+#
+- replace:
+    dest: /etc/ssh/sshd_config
+    regexp: '^#?[\s]*PrintLastLog.*$'
+    replace: 'PrintLastLog no'
+- replace:
+    dest: /etc/pam.d/sshd
+    regexp: '^(session[\s]+optional[\s]+pam_motd\.so.*)$'
+    replace: '#\1'
+
+#
 # Enable SNMP client tools to load MIBs by default.
 #
 - replace:


### PR DESCRIPTION
Tested by scp-ing updated main.yml onto target vm and rebooting.