### PR TITLE
Use "ConditionFirstBoot" to reduce bootup latency

### DIFF
--- a/lib/systemd/system/delphix-platform.service
+++ b/lib/systemd/system/delphix-platform.service
@@ -19,9 +19,19 @@ Description=Delphix Appliance Platform Service
 After=local-fs.target
 Before=rsync.service
 
+#
+# Consumers of this service (e.g. upgrade, factory reset, etc.) are aware
+# of this file and it's implications. Thus, if we ever need to change this
+# file's path, we'll likely have to also update all of the consumers of
+# this service; since these consumers may rely on removing this file, in
+# order to force this service to re-run.
+#
+ConditionPathExists=!/etc/delphix-platform/ansible-done
+
 [Service]
 Type=oneshot
 ExecStart=/etc/delphix-platform/ansible/apply
+ExecStartPost=/usr/bin/touch /etc/delphix-platform/ansible-done
 
 #
 # Environment variables sorted alphabetically based on variable name.


### PR DESCRIPTION
Problem
=======

Using "systemd-analyze" to inspect the bootup latency, we can quickly
see the "delphix-platform" adds considerable latency to bootup time.

Since the "delphix-mgmt" service depends on "delphix-platform", any time
required to execute the "delphix-platform" service directly affects the
latency for the "delphix-mgmt" to come up after a reboot.

Here's an example from a system without this change:

    $ systemd-analyze blame | head -n2
        1min 20.155s delphix-mgmt.service
             18.660s delphix-platform.service

From this, we see it takes over 18s to execute the "delphix-platform"
service; this translates to 18 seconds of additional downtime for the
"delphix-mgmt" service.

Solution
========

To address this issue, this change modifies the "delphix-platform"
service configuration to only run on the system's first boot. This will
allow the service to configure the system during the first boot (which
will obviously entail some bootup latency), but will prevent the service
from running again after that initial configuration (eliminating the
additional bootup latency caused by this service for subsequent boots).

Here's an example from a system with this change:

    $ systemd-analyze blame | grep delphix-platform
    $ systemd-analyze blame | head -n2
        1min 17.140s delphix-mgmt.service
             10.456s rtslib-fb-targetctl.service

In this example, the "delphix-platform" doesn't add any additional
latency to the bootup time, because the service didn't execute as this
wasn't the first boot for the system.

Caveats
=======

The caveat to this approach being, "delphix-platform" service will no
longer automatically run after an upgrade of the Delphix appliance.

Since we actually do want this service to run after an upgrade, the
logic/scripts we used to orchestrate the upgrade will need to be aware
of this solution, and force it to run (e.g. by removing the
/etc/machine-id as part of the upgrade).