### PR TITLE
Apply configuration once, to reduce bootup latency

### DIFF
--- a/etc/delphix-platform/ansible/apply
+++ b/etc/delphix-platform/ansible/apply
@@ -42,6 +42,36 @@ function apply_playbook() {
 	fi
 }
 
+#
+# To reduce the bootup latency and the latency to start services that
+# depend on this service, we only want to apply the configuration a
+# single time. This way, the configuration will be applied on the first
+# boot, but not on subsequent boots. This will allow the bootup time for
+# the subsequent boots to be quicker.
+#
+# Thus, if this "ansible-done" file is present, this signifies that the
+# ansible configuration has already been applied, so there's no need to
+# apply this configuration again.
+#
+# We don't use Systemd's "ConditionPathExists" directive to disable the
+# service after it's been run once, for a couple of reasons:
+#
+# 1. That would cause the service to enter a "failed" state when the
+#    file exists. This isn't the behavior we want, since it then makes
+#    it more difficult for other services to depend on this service
+#    running successfully.
+#
+# 2. When the file exists, restarting "delphix-platform" would not
+#    result in restarting services that depend on "delphix-platform". We
+#    rely on restarts to "delphix-platfrom" causing restarts to all
+#    dependent services, so we need to ensure this functionality
+#    continues to work, even if the ansible configuration doesn't have
+#    to be re-applied.
+#
+if [[ -f /etc/delphix-platform/ansible-done ]]; then
+	exit 0
+fi
+
 if [[ -z "$DLPX_ANSIBLE_DIRECTORY" ]]; then
 	echo "DLPX_ANSIBLE_DIRECTORY is unset." >&2
 	exit 1
@@ -65,3 +95,22 @@ fi
 find_playbooks | while read -r playbook; do
 	apply_playbook "$playbook"
 done
+
+#
+# This script is executed as part of the appliance-build process so that
+# configuration that's required before the first boot (e.g. bootloader)
+# can be applied using the same mechanism as configuration that can be
+# applied after the first boot.
+#
+# Thus, when this script is executed in this way, via appliance-build,
+# we need to be careful not to try to create this file. Otherwise we'd
+# modify the root filesystem of the system running the build, rather
+# than the Delphix appliance's root filesystem that's being configured.
+#
+# We detect if this script is being executed via appliance-build or not,
+# by inspecting this environment variable. It will be set to "chroot"
+# only by appliance-build; otherwise it should contain the value "local".
+#
+if [[ "$DLPX_ANSIBLE_CONNECTION" != "chroot" ]]; then
+	touch /etc/delphix-platform/ansible-done
+fi

--- a/lib/systemd/system/delphix-platform.service
+++ b/lib/systemd/system/delphix-platform.service
@@ -22,7 +22,7 @@ Before=rsync.service
 [Service]
 Type=oneshot
 ExecStart=/etc/delphix-platform/ansible/apply
-ExecReload=/bin/true
+ExecReload=/bin/rm -f /etc/delphix-platform/ansible-done
 RemainAfterExit=yes
 
 #


### PR DESCRIPTION
Problem
=======

Using "systemd-analyze" to inspect the bootup latency, we can quickly
see the "delphix-platform" adds considerable latency to bootup time.

Since the "delphix-mgmt" service depends on "delphix-platform", any time
required to execute the "delphix-platform" service directly affects the
latency for the "delphix-mgmt" to come up after a reboot.

Here's an example from a system without this change:

    $ systemd-analyze blame | head -n2
        1min 20.155s delphix-mgmt.service
             18.660s delphix-platform.service

From this, we see it takes over 18s to execute the "delphix-platform"
service; this translates to 18 seconds of additional downtime for the
"delphix-mgmt" service.

Solution
========

To address this issue, this change modifies the "delphix-platform"
service to only run the ansible configuration a single time. This will
allow the service to configure the system during the first boot (which
will obviously entail some bootup latency), but will prevent the service
from running the same ansible configuration on subsequent boots
(eliminating the additional bootup latency caused by this service for
these subsequent boots).

Here's an example from a system with this change:

    $ sudo systemd-analyze blame | head -n2
        1min 22.222s delphix-mgmt.service
             10.496s rtslib-fb-targetctl.service

    $ sudo systemd-analyze blame | grep delphix-platform
               123ms delphix-platform.service

In this example, the "delphix-platform" now adds a very minimal amount
of additionally latency to the bootup time, because the service doesn't
have to re-apply the ansible configuration that's already been applied.

Caveats
=======

The caveat to this approach being, "delphix-platform" service will no
longer automatically apply new configuration changes after an upgrade of
the Delphix appliance.

Since we actually do want re-apply the ansible configuration after an
upgrade (e.g. because the ansible logic may have been changed due to the
upgrade), the logic/scripts we use to orchestrate the upgrade will need
to be aware of this solution, and force it to run (e.g. by removing the
/etc/delphix-platform/ansible-done file as part of the upgrade).