### PR TITLE
Add "ExecReload" to prep for future changes

### DIFF
--- a/lib/systemd/system/delphix-platform.service
+++ b/lib/systemd/system/delphix-platform.service
@@ -22,6 +22,8 @@ Before=rsync.service
 [Service]
 Type=oneshot
 ExecStart=/etc/delphix-platform/ansible/apply
+ExecReload=/bin/true
+RemainAfterExit=yes
 
 #
 # Environment variables sorted alphabetically based on variable name.


### PR DESCRIPTION
This change enables running "systemctl reload" on the delphix-platform
service, but doing so doesn't yet do anything useful. The intent is to
allow the command to pass when it's run, so we update consumers of the
service to use this command, without introducing specific types of
failures. Later, we'll update the delphix-platform service to use this
reload functionality to do useful work (this will be transparent to
consumers of the service).