### PR TITLE
Create platform-specific packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
   - docker
 
 env:
-  - TARGET=package
+  - TARGET=packages
   - TARGET=shellcheck
   - TARGET=shfmtcheck
 

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@
 # limitations under the License.
 #
 
+ALL_PLATFORMS := aws azure esx gcp kvm
+
 #
 # The version field defaults to a timestamp. Note that it can be
-# overridden by running: make package VERSION="<custom version>"
+# overridden by running: make packages VERSION="<custom version>"
 #
 VERSION := $(shell date '+%Y.%m.%d.%H')
 
@@ -28,27 +30,28 @@ VERSION := $(shell date '+%Y.%m.%d.%H')
 
 check: shellcheck shfmtcheck
 
-package:
+packages: $(addprefix package-,$(ALL_PLATFORMS))
+
+package-%:
 	@rm -f debian/changelog
 	dch --create --package delphix-platform -v $(VERSION) \
 			"Automatically generated changelog entry."
-	dpkg-buildpackage -us
-	@for ext in dsc tar.xz; do \
+	sed "s/@@TARGET_PLATFORM@@/$*/" debian/control.in >debian/control
+	TARGET_PLATFORM=$* dpkg-buildpackage -us
+	@for ext in buildinfo changes dsc tar.xz; do \
 		mv -v ../delphix-platform_*.$$ext artifacts; \
 	done
+	@mv -v ../delphix-platform-$*_*_amd64.deb artifacts
 
-	@for ext in buildinfo changes deb; do \
-		mv -v ../delphix-platform_*_amd64.$$ext artifacts; \
-	done
+SHELL_SCRIPTS := \
+	debian/postinst \
+	debian/prerm \
+	usr/bin/download-latest-image \
+	usr/bin/unpack-image \
+	var/lib/delphix-platform/ansible/apply
 
 shellcheck:
-	shellcheck \
-		usr/bin/download-latest-image \
-		usr/bin/unpack-image \
-		var/lib/delphix-platform/ansible/apply
+	shellcheck $(SHELL_SCRIPTS)
 
 shfmtcheck:
-	! shfmt -d \
-		usr/bin/download-latest-image \
-		usr/bin/unpack-image \
-		var/lib/delphix-platform/ansible/apply | grep .
+	! shfmt -d $(SHELL_SCRIPTS) | grep .

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Run this command on "dlpxdc.co" to create the VM used to do the build:
 
 Log into that VM using the "ubuntu" user, and run these commands:
 
-    $ git clone https://github.com/prakashsurya/delphix-platform.git
+    $ git clone https://github.com/delphix/delphix-platform.git
     $ cd delphix-platform
     $ ansible-playbook bootstrap/playbook.yml
-    $ ./scripts/docker-run.sh make package
+    $ ./scripts/docker-run.sh make packages
 
 ## Statement of Support
 

--- a/debian/control.in
+++ b/debian/control.in
@@ -21,7 +21,15 @@ Maintainer: Delphix Engineering <eng@delphix.com>
 Build-Depends: debhelper (>= 10), devscripts
 Standards-Version: 4.1.2
 
-Package: delphix-platform
+#
+# Note that the 'Conflicts' field prevents two packages which provide
+# delphix-platform from being installed at the same time. We can never have
+# more than one of these packages installed because they try to install some of
+# the same files.
+#
+Package: delphix-platform-@@TARGET_PLATFORM@@
+Provides: delphix-platform
+Conflicts: delphix-platform
 Architecture: any
 Replaces: base-files
 Depends: ${misc:Depends}, ${delphix:Depends}

--- a/debian/postinst
+++ b/debian/postinst
@@ -16,12 +16,10 @@
 #
 
 case $1 in
-    configure)
+configure)
 	systemctl enable auditd.service
 	systemctl enable delphix-platform.service
 	systemctl enable systemd-networkd.service
-
-	systemctl disable walinuxagent.service
 	;;
 esac
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -16,7 +16,7 @@
 #
 
 case $1 in
-    upgrade|remove)
+upgrade | remove)
 	#
 	# Removal is not quite the opposite of installation; we leave the
 	# non-delphix services alone, even if the postinst script changed

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,13 @@
 # limitations under the License.
 #
 
+# Map supported platform to the kernel type that it uses.
+KERNEL_TYPE.aws := aws
+KERNEL_TYPE.azure := azure
+KERNEL_TYPE.esx := generic
+KERNEL_TYPE.gcp := gcp
+KERNEL_TYPE.kvm := kvm
+
 #
 # The following meta-package consolidates all the kernel packages required
 # by the Delphix Appliance for a given platform. Note that delphix-kernel
@@ -23,7 +30,7 @@
 # to a particular kernel version should be included in the "tools.list.chroot"
 # file.
 #
-DEPENDS = delphix-kernel,
+DEPENDS = delphix-kernel-$(KERNEL_TYPE.$(TARGET_PLATFORM)),
 
 #
 # The following packages are required in order to generate VM artifacts
@@ -42,12 +49,10 @@ DEPENDS += ansible, \
 	   debootstrap, \
 	   debsums, \
 	   net-tools, \
-	   open-vm-tools, \
 	   openssh-server, \
 	   rng-tools, \
 	   systemd-container, \
-	   ubuntu-minimal, \
-	   walinuxagent,
+	   ubuntu-minimal,
 
 #
 # The following package contains the GPG keys which allow us to download
@@ -61,6 +66,14 @@ DEPENDS += ubuntu-dbgsym-keyring,
 # framework.
 #
 DEPENDS += delphix-extra,
+
+# Platform-specific dependencies
+DEPENDS.aws =
+DEPENDS.azure = walinuxagent,
+DEPENDS.esx = open-vm-tools,
+DEPENDS.gcp =
+DEPENDS.kvm =
+DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 
 #
 # These packages are tools that are intended for human convenience. The
@@ -110,9 +123,7 @@ override_dh_gencontrol:
 override_dh_auto_build:
 	#
 	# Don't run default make target during the build step; there
-	# isn't anything that needs to be built. Further, since the
-	# default make target is "package", without this override, an
-	# infinite loop would occur: make package -> make package -> ...
+	# isn't anything that needs to be built.
 	#
 
 override_dh_auto_test:

--- a/usr/bin/download-latest-image
+++ b/usr/bin/download-latest-image
@@ -59,5 +59,5 @@ aws s3 cp \
 $opt_f && rm -f "$1.upgrade.tar.gz" >/dev/null 2>&1
 [[ -f "$1.upgrade.tar.gz" ]] && die "image $1.upgrade.tar.gz already exists"
 
-aws s3 cp "s3://snapshot-de-images/$(cat latest)/$1.upgrade.tar.gz" . ||
+aws s3 cp "s3://snapshot-de-images/$(cat latest)/upgrade-artifacts/$1.upgrade.tar.gz" . ||
 	die "failed to download file: '$1.upgrade.tar.gz'"


### PR DESCRIPTION
Create an instance of the delphix-platform package for each platform
that we support. The package depends on the appropriate version of
delphix-kernel, and contains other platform-specific dependencies where
appropriate.