### PR TITLE
DLPX-61685 Increase journalctl log storage space

### DIFF
--- a/etc/systemd/journald.conf.d/override.conf
+++ b/etc/systemd/journald.conf.d/override.conf
@@ -5,4 +5,4 @@
 #
 [Journal]
 Storage=persistent
-SystemMaxUse=250M
+SystemMaxUse=2.5G


### PR DESCRIPTION
The current log size limit (250M) is met quite quickly in the context of our normal blackbox testing (I was looking at the precheckin scope, in particular). I was able to determine that at the worst point, the journal only has 20 minutes worth of logs. Since this test scope runs about 3 hours, I decided to increase the size limit by a factor of 10 so that logs are available that cover the whole duration (plus some buffer, as tests might not be looked at immediately).  