### PR TITLE
Enable SCSI-3 persistent reservations

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -124,3 +124,4 @@ override_dh_auto_test:
 override_dh_auto_install:
 	dh_install etc/* /etc
 	dh_install lib/* /lib
+	dh_install var/* /var

--- a/var/target/pr/README
+++ b/var/target/pr/README
@@ -1,0 +1,7 @@
+The /var/target/pr directory is used by the LinuxIO (LIO) framework to
+store persistent reservation data. If this directory is not present then
+SCSI-3 reservations will not work on iSCSI LUNs exposed by LIO, which are
+required by Windows Server Failover Cluster.
+
+Do not delete this README from source as this will remove the /var/target/pr
+directory from git.


### PR DESCRIPTION
**DESCRIPTION**

Directory /var/target/pr must be present on the system for
SCSI-3 persistent reservations to work as the LIO "target" driver
creates files under it to store persistent reservation
information.

This is related to https://jira.delphix.com/browse/DLPX-61906.

**TESTING**

- pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/341/
- Tested that SCSI-3 reservations work by running tests on a Windows target environment against a LUN exposed by the DE:
```
C:\Users\dtully\Downloads>scsicmd -d3 -sscsi3_test
...
====>  SCSI-3 PERSISTENT OPERATION TESTS: All tests are PASSED on harddisk3.
```
- Jeff tested that we can successfully add the LUN to a Windows Server Failover Cluster.