### PR TITLE
Create and preserve "/var/log/delphix-upgrade" directory

### DIFF
--- a/etc/cron.daily/delphix-upgrade-logs
+++ b/etc/cron.daily/delphix-upgrade-logs
@@ -14,8 +14,6 @@ find /var/log/delphix-upgrade -type f -mtime +7 -delete
 
 #
 # After the old files have been deleted, we need to remove any empty
-# directories; this includes "/var/log/delphix-upgrade" itself. The
-# assumption is "/var/delphix-upgrade" will be created by the upgrade
-# scripts if it doesn't already exist.
+# directories, excluding "/var/log/delphix-upgrade" itself.
 #
-find /var/log/delphix-upgrade -type d -mtime +7 -empty -delete
+find /var/log/delphix-upgrade -mindepth 1 -type d -mtime +7 -empty -delete

--- a/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -60,6 +60,15 @@
     mode: 0777
 
 #
+# This directory is used by upgrade; it's bind mounted into the upgrade
+# container such that software can write files to this directory, and
+# these files can easily be accessed by software running on the host.
+#
+- file:
+    path: /var/log/delphix-upgrade
+    state: directory
+
+#
 # Create the directory and ZFS dataset that we'll use to store unpacked
 # upgrade images. This directory is used by the upgrade related scripts
 # found in this directory, but also used by upgrade-scripts stored in


### PR DESCRIPTION
When performing an upgrade via the virtualization API, the application
will attempt to create a file in "/var/log/delphix-upgrade" prior to
executing any of the upgrade scripts. This file creation currently fails
because the "/var/log/delphix-upgrade" directory will not exist at that
point (that directory is created by the upgrade scripts).

This change fixes the problem by creating this directory via the
delphix-platform service (which runs on first boot, prior to the
virtualization application running), and also updates the associated
cron entry to ensure the directory is not removed.