### PR TITLE
Re-add some tools formerly pulled in by open-vm-tools

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -86,6 +86,7 @@ DEPENDS += bpfcc-tools, \
 	   dnsutils, \
 	   dstat, \
 	   emacs-nox, \
+	   ethtool, \
 	   gdb, \
 	   glances, \
 	   htop, \
@@ -100,6 +101,7 @@ DEPENDS += bpfcc-tools, \
 	   manpages-dev, \
 	   memstat, \
 	   ncdu, \
+	   pciutils, \
 	   procinfo, \
 	   psmisc, \
 	   pv, \


### PR DESCRIPTION
Certain tools that developers commonly use (`lspci` and `ethtool` in
particular) used to be pulled in when we installed `open-vm-tools`. Now we
only install `open-vm-tools` on ESX, so we should add explicit
dependencies on those tools so that they are installed on all platforms.