### PR TITLE
remove bpfcc-tools

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -80,8 +80,7 @@ DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 # product should not rely on them programmatically. They may be updated
 # or replaced without regard for backward compatibility.
 #
-DEPENDS += bpfcc-tools, \
-	   bpftrace, \
+DEPENDS += bpftrace, \
 	   crash, \
 	   dnsutils, \
 	   dstat, \


### PR DESCRIPTION
We will replace the `bpfcc-tools` that comes with Ubuntu by `bcc-tools` that comes from building the `bcc` linux-pkg project. To avoid flag days, and since we do not have any code dependencies on bpfcc-tools, we start by removing `bpfcc-tool`. `bcc-tools` will be re-added in a subsequent commit.

Note that removing `bpfcc-tools` is necessary for https://github.com/delphix/linux-pkg/pull/12, since `bpfcc-tools` pulls in `libbpfcc`, which conflicts with `libbcc`.

## TESTING
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/419/