### PR TITLE
Don't run zpool command during appliance-build

### DIFF
--- a/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -55,6 +55,7 @@
 #
 - command: zpool list -Hpo size rpool
   register: rpool_size_bytes
+  when: not ansible_is_chroot
 
 #
 # We want to store crash dumps on a specific dataset for a couple


### PR DESCRIPTION
We need to be careful with our delphix-platform service's Ansible code,
and ensure we don't execute commands that would need the ZFS modules
during appliance-build. We accomplish this by causing these tasks not to
run when it detects Ansible is being run in a "chroot" environment.
Unfortunately, a prior change did not properly guard against a "zpool"
invocation, which is causing builds to fail; this change adds the guard,
which should fix the build failures.