### PR TITLE
Temporarily restart ssh service postinstall to apply sshd configuration

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -21,6 +21,13 @@ configure)
 	systemctl enable delphix-platform.service
 	systemctl enable systemd-networkd.service
 
+	#
+	# We restart the ssh service as a stop-gap solution
+	# for DLPX-62465. We should rethink how to handle
+	# the application of sshd_config.
+	#
+	systemctl restart ssh
+
 	if ! id -u postgres >/dev/null; then
 		# When installing postgres, a postgres user is created unless it
 		# already exists. To have a consistent UID accross installations


### PR DESCRIPTION
Testing on a brand new VM that ssh was restarted.
```
$ systemctl status sshd
● ssh.service - OpenBSD Secure Shell server
   Loaded: loaded (/lib/systemd/system/ssh.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2019-01-28 17:02:29 UTC; 6min ago
 Main PID: 1512 (sshd)
    Tasks: 1 (limit: 4915)
   CGroup: /system.slice/ssh.service
           └─1512 /usr/sbin/sshd -D
$ sudo dpkg -i delphix-platform-aws_2019.01.28.16_amd64.deb
(Reading database ... 115301 files and directories currently installed.)
Preparing to unpack delphix-platform-aws_2019.01.28.16_amd64.deb ...
+ case $1 in
+ systemctl disable delphix-platform.service
+ rm -f /var/lib/delphix-platform/ansible-done
+ exit 0
Unpacking delphix-platform-aws (2019.01.28.16) over (2019.01.28.16) ...
Setting up delphix-platform-aws (2019.01.28.16) ...
+ case $1 in
+ systemctl enable auditd.service
Synchronizing state of auditd.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable auditd
+ systemctl enable delphix-platform.service
Created symlink /etc/systemd/system/default.target.wants/delphix-platform.service → /lib/systemd/system/delphix-platform.service.
+ systemctl enable systemd-networkd.service
+ systemctl restart ssh
+ id -u postgres
++ id -u postgres
+ [[ 65437 -ne 65437 ]]
+ exit 0
$ systemctl status sshd
● ssh.service - OpenBSD Secure Shell server
   Loaded: loaded (/lib/systemd/system/ssh.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2019-01-28 17:11:45 UTC; 4s ago
  Process: 10614 ExecStartPre=/usr/sbin/sshd -t (code=exited, status=0/SUCCESS)
 Main PID: 10616 (sshd)
    Tasks: 1 (limit: 4915)
   CGroup: /system.slice/ssh.service
           └─10616 /usr/sbin/sshd -D
```

WIP: Test that local port forwarding is disabled and configuration was actually applied