### PR TITLE
Propagate Ansible errors in 'apply' script

### DIFF
--- a/var/lib/delphix-platform/ansible/apply
+++ b/var/lib/delphix-platform/ansible/apply
@@ -27,7 +27,7 @@ function find_playbooks() {
 		-mindepth 2 \
 		-name playbook.yml | sort -n; then
 		echo "Failure when finding playbooks." 2>&1
-		exit 1
+		return 1
 	fi
 
 	#
@@ -36,13 +36,12 @@ function find_playbooks() {
 	# old directory. Once all consumers can be updated to install
 	# into the new directory, we can remove this logic.
 	#
-	if ! find "/etc/delphix-platform/ansible" \
+	find "/etc/delphix-platform/ansible" \
 		-maxdepth 2 \
 		-mindepth 2 \
-		-name playbook.yml | sort -n; then
-		echo "Failure when finding playbooks." 2>&1
-		exit 1
-	fi
+		-name playbook.yml | sort -n
+
+	return 0
 }
 
 function apply_playbook() {
@@ -106,7 +105,8 @@ if [[ "$(find_playbooks | wc -l)" -eq "0" ]]; then
 	exit 1
 fi
 
-find_playbooks | while read -r playbook; do
+playbooks=$(find_playbooks) || exit 1
+for playbook in $playbooks; do
 	apply_playbook "$playbook"
 done
 


### PR DESCRIPTION
The 'apply_playbook' function runs in a sub-shell because it is called
in a pipeline, so the 'exit 1' in that function only exits from the
sub-shell. We need to check the exit status of the sub-shell from the
main shell in order to propagate errors.

Fixes https://github.com/delphix/appliance-build/issues/215