### PR TITLE
End support of "/etc/delphix-platform/ansible" directory

### DIFF
--- a/etc/delphix-platform/ansible/README
+++ b/etc/delphix-platform/ansible/README
@@ -1,6 +1,0 @@
-This file is temporarily maintained for backwards compatibility of
-programs that will attempt to install ansible configuration into this
-directory. Originally, /etc/delphix-platform/ansible was the directory
-used for storing ansible configuration consumed by the delphix-platform
-service, but this has since moved to /var/lib/delphix-platform to better
-comply with the Filesystem Hierarchy Standard (FHS).

--- a/var/lib/delphix-platform/ansible/apply
+++ b/var/lib/delphix-platform/ansible/apply
@@ -29,19 +29,6 @@ function find_playbooks() {
 		echo "Failure when finding playbooks." 2>&1
 		return 1
 	fi
-
-	#
-	# Temporarily, we need to maintain backwards compatibility with
-	# software that still installs ansible configuration into the
-	# old directory. Once all consumers can be updated to install
-	# into the new directory, we can remove this logic.
-	#
-	find "/etc/delphix-platform/ansible" \
-		-maxdepth 2 \
-		-mindepth 2 \
-		-name playbook.yml | sort -n
-
-	return 0
 }
 
 function apply_playbook() {


### PR DESCRIPTION
Previously, in commit 37809a574e9e209a4a58020b7155a13aea85d13d we moved
the location of the delphix-platform service's ansible files from "/etc"
to "/var/lib". Since, at that time, consumers of the delphix-platform
service would still install files in "/etc", we couldn't completely drop
support for the "/etc/delphix-platform/ansible" directory.

Now that consumers have been updated to stop installing files into the
"/etc/delphix-platform/ansible" directory, we can safely drop support
for this directory, and support only the "/var/lib" directory.