### PR TITLE
Add bcc-tools debug package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -80,7 +80,8 @@ DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 # product should not rely on them programmatically. They may be updated
 # or replaced without regard for backward compatibility.
 #
-DEPENDS += bpftrace, \
+DEPENDS += bcc-tools, \
+	   bpftrace, \
 	   crash, \
 	   dnsutils, \
 	   dstat, \


### PR DESCRIPTION
Adds back `bpfcc-tools` as `bcc-tools` removed by https://github.com/delphix/delphix-platform/pull/40.

## TESTING
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/40/
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/456/
