### PR TITLE
bcc-tools product dependency

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -45,6 +45,7 @@ DEPENDS += grub-pc, \
 #
 DEPENDS += ansible, \
 	   auditd, \
+	   bcc-tools, \
 	   cloud-init, \
 	   debootstrap, \
 	   debsums, \
@@ -80,8 +81,7 @@ DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 # product should not rely on them programmatically. They may be updated
 # or replaced without regard for backward compatibility.
 #
-DEPENDS += bcc-tools, \
-	   bpftrace, \
+DEPENDS += bpftrace, \
 	   crash, \
 	   dnsutils, \
 	   dstat, \


### PR DESCRIPTION
With the analytics scripts such as the nfs collector using bcc it needs to be included in the product dependencies 