### PR TITLE
LX-1770 Add our custom td-agent to delphix-platform

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -61,11 +61,16 @@ DEPENDS += ansible, \
 DEPENDS += ubuntu-dbgsym-keyring,
 
 #
-# This package contains a consolidation for third-party packages built
-# by delphix as well as build info for all packages built by the linux-pkg
-# framework.
+# This package provides the build information for all packages built by
+# the linux-pkg framework.
 #
 DEPENDS += delphix-extra,
+
+#
+# The following packages provide additional set of packages that are
+# common part of the Delphix platform.
+#
+DEPENDS += td-agent,
 
 # Platform-specific dependencies
 DEPENDS.aws =


### PR DESCRIPTION
This adds our custom td-agent package built via linux-pkg framework to `delphix-platform`
and depends on LX-1645 to build the custom td-agent package.

* appliance-build-orchestrator run that uses this and corresponding linux-pkg changes   : http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/506/console
* Created a VM based on the resulting image and the custom `td-agent` is installed by default as expected

```
psreenivasa@dlpxdc$ dc clone-latest dlpx-psreenivasa-master pks-lx-1645-new
pks-lx-1645-new - dlpx-psreenivasa-master
psreenivasa@dlpxdc$

delphix@ip-10-110-215-46:~$ uname -a
Linux ip-10-110-215-46 4.15.0-1032-aws #34-Ubuntu SMP Thu Jan 17 15:18:09 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
delphix@ip-10-110-215-46:~$
delphix@ip-10-110-215-46:~$
delphix@ip-10-110-215-46:~$ sudo apt show td-agent
Package: td-agent
Version: 3.3.0-delphix-2019.02.19.22
Status: install ok installed
Priority: extra
Section: misc
<<<snip>>>
```
