### PR TITLE
Fix cloud-init configuration priority

### DIFF
--- a/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
+++ b/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
@@ -15,6 +15,12 @@
 #
 
 #
+# The configuration in this file has to be applied after 90_dpkg.cfg,
+# which is created by the cloud-init package's postinstall script.
+# Otherwise the value of 'datasource_list' set here will be reset.
+#
+
+#
 # While we create the user using Ansible, we need to inform cloud-init
 # of this user so that SSH keys are properly inserted into this user's
 # authorized_keys file (e.g. when running in EC2). Additionally, this


### PR DESCRIPTION
Currently our setting for datasource_list is being overridden by a
configuration file generated by the cloud-init package. This results in
cloud-init executing whatever userdata it is passed, even on the
external-standard variant. We can make sure our setting gets used by
renaming the configuration file so that it is read after the one
generated by cloud-init.