### PR TITLE
LX-1627 Create a service to run post-boot migration logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ SHELL_SCRIPTS := \
 	debian/prerm \
 	usr/bin/download-latest-image \
 	usr/bin/unpack-image \
-	var/lib/delphix-platform/ansible/apply
+	var/lib/delphix-platform/ansible/apply \
+	var/lib/delphix-platform/os-migration
 
 shellcheck:
 	shellcheck $(SHELL_SCRIPTS)

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2019 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 case $1 in
 configure)
 	systemctl enable auditd.service
+	systemctl enable delphix-migration.service
 	systemctl enable delphix-platform.service
 	systemctl enable systemd-networkd.service
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2019 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ upgrade | remove)
 	# so we can't reliably restore the system back to that prior state.
 	#
 
+	systemctl disable delphix-migration.service
 	systemctl disable delphix-platform.service
 
 	#

--- a/lib/systemd/system/delphix-migration.service
+++ b/lib/systemd/system/delphix-migration.service
@@ -1,0 +1,50 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# We want to execute this service as early as possible since it will be
+# finalizing the network configuration after an OS migration. Since it will
+# also be importing domain0, which is normally imported by the
+# zfs-import-cache service, we add similar dependencies to it
+# (i.e. devices must be ready, so run after systemd-udev-settle.service, and
+# service is required by zfs-import.target). Finally, we must make sure to
+# remove default service dependencies, as those would create a dependency
+# cycle (this service must run before local-fs.target, but default
+# dependencies require local-fs.target). Note that the zfs-import.target
+# dependency means that this service will run before local-fs.target, and so
+# before any other Delphix service.
+#
+[Unit]
+Description=Delphix OS Migration Service
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Before=network-pre.target
+Before=zfs-import.target
+
+[Service]
+Type=oneshot
+ExecStart=/var/lib/delphix-platform/os-migration
+RemainAfterExit=yes
+
+#
+# Disable the service once it has run.
+# Even though the service does nothing when the flag file is not there,
+# disabling it has the advantage of simplifying systemd dependencies.
+#
+ExecStartPost=/bin/systemctl disable delphix-migration.service
+
+[Install]
+WantedBy=default.target

--- a/lib/systemd/system/delphix-platform.service
+++ b/lib/systemd/system/delphix-platform.service
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2019 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/var/lib/delphix-platform/os-migration
+++ b/var/lib/delphix-platform/os-migration
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MIGRATE_CONFIG_SCRIPT="/opt/delphix/migration/migrate_config.py"
+MIGRATE_CONFIG_LOG="/var/delphix/migration/log"
+
+# The perform-migration flag file is created by dx_execute prior rebooting into
+# Linux.
+PERFORM_MIGRATION="/var/delphix/migration/perform-migration"
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+function perform_migration() {
+	zpool import -f domain0 || die "Failed to import domain0"
+	# domain0/mds is owned by delphix:staff on Illumos, and on Linux
+	# postgres can't access this dataset anymore. We change the permissions
+	# to the Linux defaults.
+	chown postgres:postgres /mds ||
+		die "Failed chowning /mds"
+	echo "$(date): Running migrate_config post-upgrade" \
+		>>"$MIGRATE_CONFIG_LOG"
+	"$MIGRATE_CONFIG_SCRIPT" post-upgrade >>"$MIGRATE_CONFIG_LOG" ||
+		die "Failed migrate_config post-upgrade"
+	rm "$PERFORM_MIGRATION" || die "Failed to remove $PERFORM_MIGRATION"
+}
+
+if [[ -f "$PERFORM_MIGRATION" ]]; then
+	echo "File $PERFORM_MIGRATION exists. Performing OS migration ..."
+	perform_migration
+else
+	echo "File $PERFORM_MIGRATION missing. Nothing to do."
+fi


### PR DESCRIPTION
This adds a new service to the appliance: `delphix-migration`.
When the service runs it looks for the `/os-migration` flag file; if the file is not there, then it exits and does nothing.
The `/os-migration` file will be created during a migration upgrade.

## RELATED WORK
- adding migrate_config.py script: http://reviews.delphix.com/r/47101/
- dx_execute call to migrate_config.py and creation of `/os-migration` file (to be posted soon)

## TESTING
- git-ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/600/ (pass)
- Manually tested migration with changes in http://reviews.delphix.com/r/47101/ and upcoming changes to dx_execute. All the services come up except delphix-mgmt (due to LX-1776).
- Ran `systemd-analyze plot` with the service enabled and disabled and verified it doesn't add any unexpected dependencies and to verify that it runs in the expected order relative to other services. Also ran `systemctl list-dependencies delphix-migration` and `systemctl list-dependencies delphix-migration --reverse`.