### PR TITLE
Create a delphix group

### DIFF
--- a/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -26,11 +26,17 @@
     state: directory
     mode: 0755
 
+- group:
+    name: delphix
+    state: present
+
 - user:
     name: delphix
     uid: 65433
     group: staff
-    groups: root
+    groups:
+      - root
+      - delphix
     shell: /bin/bash
     create_home: yes
     comment: Delphix User


### PR DESCRIPTION
This commit adds a "delphix" group to the system so that the masking
user can get permissions on root-owned files without having to relax the
ownership of those files for other users. The "delphix" user will also
be added to this group for convenience.

### Testing

I added the ansible role changes to a VM and re-applied the role. The result:
```
delphix@seb-linux:~$ groups
staff root delphix
delphix@seb-linux:~$ grep ^delphix /etc/group
delphix:x:1000:delphix
```