### PR TITLE
Bump /var/dlpx-update quota to 30g

### DIFF
--- a/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -128,7 +128,13 @@
     extra_zfs_properties:
       mountpoint: /var/dlpx-update
       compression: gzip
-      quota: 15g
+      #
+      # internal-qa migration images are currently 5G in size and internal-dev
+      # are 11.5G. We need double that space as the uploaded image is unpacked
+      # in the same dataset, thus requiring a minimum of 23G. We use 30G to
+      # leave a safety margin of a few GBs.
+      #
+      quota: 30g
   when: not ansible_is_chroot
 
 #


### PR DESCRIPTION
Currently running a linux migration upgrade with an internal-dev image consumes 22.9 GB of space on /var/dlpx-upgrade, causing the delphix-platform service to fail on boot as it tries to reduce the quota below the space used.

Relevant error:
```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "createparent": null,
            "extra_zfs_properties": {
                "compression": "gzip",
                "mountpoint": "/var/
                "quota": "15g"
            },
            "name": "rpool/update",
            "origin": null,
            "state": "present"
        }
    },
    "msg": "cannot set property for 'rpool/update': size is less than current used or reserved space\n
}
```

## TESTING

git-ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/617