### PR TITLE
LX-1595 customize gcp guest environment

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -71,7 +71,8 @@ DEPENDS += delphix-extra,
 DEPENDS.aws =
 DEPENDS.azure = walinuxagent,
 DEPENDS.esx = open-vm-tools,
-DEPENDS.gcp =
+DEPENDS.gcp = gce-compute-image-packages, python-google-compute-engine, \
+	   python3-google-compute-engine,
 DEPENDS.kvm =
 DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 

--- a/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
+++ b/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
@@ -1,0 +1,25 @@
+#
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+#
+# Apply any changes made to the override instance config file. This
+# can only be done when we're on a running gcp instance.
+#
+- command: /usr/bin/google_instance_setup
+  listen: "gcp config changed"
+  when: not ansible_is_chroot

--- a/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -302,3 +302,39 @@
     #
     - { key: 'AutoUpdate.Enabled', value: 'n' }
   when: platform == "azure"
+
+#
+# Customize the GCP linux environment.
+#
+# Update the override file for the GCP instance. This file gets
+# applied dynamically by running google_instance_setup script.
+#
+- blockinfile:
+    path: /etc/default/instance_configs.cfg.template
+    create: yes
+    block: |
+      #
+      # Disable the accounts daemon to prevent adding/removing
+      # users on the engine.
+      #
+      [Daemons]
+      accounts_daemon = false
+
+      #
+      # Disable user supplied startup/shutdown scripts from running on
+      # the engine.
+      #
+      [MetadataScripts]
+      shutdown = false
+      startup = false
+  when:
+    - platform == "gcp"
+  notify: "gcp config changed"
+
+#
+# Make sure that the account daemon is always disabled. The override file
+# above should prevent this and this is designed to catch any corner cases.
+#
+- command: systemctl disable google-accounts-daemon.service
+  when:
+    - platform == "gcp"


### PR DESCRIPTION
This adds the Linux Guest Environment so GCP variant of the delphix platform and configures the override file to ensure that only the appropriate functionality is enabled. We disable the account daemon to prevent users from being added and disable the metadata scripts to prevent running random scripts on the delphix engine.