### PR TITLE
TOOL-7390 Remove delphix-extra package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -60,13 +60,6 @@ DEPENDS += ansible, \
 #
 DEPENDS += ubuntu-dbgsym-keyring,
 
-#
-# This package contains a consolidation for third-party packages built
-# by delphix as well as build info for all packages built by the linux-pkg
-# framework.
-#
-DEPENDS += delphix-extra,
-
 # Platform-specific dependencies
 DEPENDS.aws =
 DEPENDS.azure = walinuxagent,


### PR DESCRIPTION
Remove the delphix-extra package as it will no longer be generated after TOOL-7303 lands.
This package only contains build metadata so the product has no dependency on it.

## TESTING

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/723/