### PR TITLE
Fixes for LX-1806 and LX-1813

### DIFF
--- a/lib/systemd/system/delphix-migration.service
+++ b/lib/systemd/system/delphix-migration.service
@@ -20,17 +20,22 @@
 # also be importing domain0, which is normally imported by the
 # zfs-import-cache service, we add similar dependencies to it
 # (i.e. devices must be ready, so run after systemd-udev-settle.service, and
-# service is required by zfs-import.target). Finally, we must make sure to
-# remove default service dependencies, as those would create a dependency
-# cycle (this service must run before local-fs.target, but default
-# dependencies require local-fs.target). Note that the zfs-import.target
-# dependency means that this service will run before local-fs.target, and so
-# before any other Delphix service.
+# service is required by zfs-import.target). The service needs to access
+# files in /var/delphix so we add a dependency on the /var/delphix mountpoint.
+# Note that /var/delphix comes from the root pool, which is imported on boot,
+# so this dependency doesn't conflict with the zfs-import.target.
+#
+# Finally, we must make sure to remove default service dependencies, as
+# those would create a dependency cycle (this service must run before
+# local-fs.target, but default dependencies require local-fs.target). Note
+# that the zfs-import.target dependency means that this service will run
+# before local-fs.target, and so before any other Delphix service.
 #
 [Unit]
 Description=Delphix OS Migration Service
 DefaultDependencies=no
 After=systemd-udev-settle.service
+After=var-delphix.mount
 Before=network-pre.target
 Before=zfs-import.target
 

--- a/var/lib/delphix-platform/os-migration
+++ b/var/lib/delphix-platform/os-migration
@@ -41,11 +41,14 @@ function perform_migration() {
 	zfs set mountpoint=/var/crash rpool/crashdump ||
 		die "Failed to set mountpoint for rpool/crashdump"
 
+	chown -R root:root /var/delphix/server ||
+		die "Failed to chown /var/delphix/server"
+
 	zpool import -f domain0 || die "Failed to import domain0"
 	# domain0/mds is owned by delphix:staff on Illumos, and on Linux
 	# postgres can't access this dataset anymore. We change the permissions
 	# to the Linux defaults.
-	chown postgres:postgres /mds ||
+	chown -R postgres:postgres /mds ||
 		die "Failed chowning /mds"
 	echo "$(date): Running migrate_config post-upgrade" \
 		>>"$MIGRATE_CONFIG_LOG"


### PR DESCRIPTION
LX-1806 migration: delphix-migration service should depend on var-delphix.mount
LX-1813 migration: /var/delphix/server should be owned by root

Summary: 
- [LX-1806](https://jira.delphix.com/browse/LX-1806): delphix-migration accesses files on `/var/delphix`, which is mounted asynchronously (it is present in /etc/fstab). Adding a dependency on the `var-delphix.mount` unit waits for /var/delphix to be mounted before starting the service.
- [LX-1813](https://jira.delphix.com/browse/LX-1813): the log rotator in delphix-platform.service failed because some logs (nginx) weren't owned by root. In general on Linux files in `/var/delphix/server` should be owned by root, so we do a recursive chown. While we are there we do the same for mds, to avoid relying on the logic in svc-postgres.sh which also does some chowning.

## TESTING
- migration testing: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/36/
   note that job failure is expected. The job is used to automate the migration
- ab-pre-commit: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/765/
- For LX-1806, checked that there are no dependency cycles between the different services involved by calling `systemctl show -p Requires,Wants,Requisite,BindsTo,PartOf,Before,After <service>` and looking for effective dependencies.
