### PR TITLE
update JAVA_HOME to adoptopenjdk

### DIFF
--- a/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -258,7 +258,7 @@
     regexp: '^{{ item.key }}='
     line: '{{ item.key }}="{{ item.value }}"'
   with_items:
-    - { key: 'JAVA_HOME', value: '/usr/lib/jvm/oracle-java8-jdk-amd64' }
+    - { key: 'JAVA_HOME', value: '/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64' }
 
 #
 # Configure the Azure agent. Only run this on Azure, since that is the


### PR DESCRIPTION
update JAVA_HOME to adoptopenJDK

**Testing:**
Linux-pkg run using forked branch of `delphix-platform` - http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/15/

appliance-build-orchestrator-pre-push : http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/792/ (still running)

Other related changes for appliance-build-orchestrator run - 

app-gate -
changes : https://gitlab.delphix.com/sravya.meda/dlpx-app-gate/commit/d382bb892ff50a936a44d824941099b0143ed037
build : http://selfservice.jenkins.delphix.com/job/dlpx-app-gate/job/master/job/build-package/job/pre-push/442/

masking -
changes : https://gitlab.delphix.com/sravya.meda/dms-core-gate/commit/eddc19da356052cecd5a14ead45f838e07fae321
build - http://selfservice.jenkins.delphix.com/job/dms-core-gate/job/master/job/build-package/job/pre-push/71/

saml-app -
changes : https://gitlab.delphix.com/sravya.meda/saml-app/commit/66aabbcee3b47171f625a8a5da9f3a9b0ab5f54e

Verify JAVA_HOME on a VM from appliance build image -
```
delphix@ip-10-110-236-58:~$ echo $JAVA_HOME
/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64
```