### PR TITLE
Turn off device initialization for Azure

### DIFF
--- a/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -304,6 +304,20 @@
   when: platform == "azure"
 
 #
+# Supply the default engine parameters
+#
+- lineinfile:
+    path: /opt/delphix/server/etc/delphix_config_override.properties.template
+    regexp: '^{{ item.key }}='
+    line: '{{ item.key }}={{ item.value }}'
+  with_items:
+    #
+    # Enable device initialization by default on all platforms except for Azure
+    #
+    - { key: 'ENABLED_FEATURES', value: 'STORAGEDEVICEINITIALIZE' }
+  when: platform != "azure"
+
+#
 # Customize the GCP linux environment.
 #
 # Update the override file for the GCP instance. This file gets


### PR DESCRIPTION
Device initialization seems to either block or slow management stack startup (despite the fact that it should be happening asynchronously), causing timeouts in blacbox tests for Azure. After some discussion, it seems that this feature does provide a significant gain for some platforms and potentially causes harm in others. At the very least, the benefits of device initialization have not been established for Azure. 

While we investigate further, I wanted to supply a mechanism to adjust the default on a platform by platform basis. An app gate change clears the default features: http://reviews.delphix.com/r/48857/diff/1/ and this change will repopulate `STORAGEDEVICEINITIALIZE` for all but `azure`. 

I've lost track of what exactly `ab-pre-push` does, but I've kicked off this job with the hope of creating and testing both `aws` and `azure` VMs: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/931/ (`git ab-pre-push -p aws,azure`)