### PR TITLE
LX-1863 migration: postgres index must be rebuilt after upgrade: delphix-platform change

### DIFF
--- a/var/lib/delphix-platform/os-migration
+++ b/var/lib/delphix-platform/os-migration
@@ -17,9 +17,12 @@
 
 MIGRATE_CONFIG_SCRIPT="/opt/delphix/migration/migrate_config.py"
 MIGRATE_CONFIG_LOG="/var/delphix/migration/log"
+PG_REINDEX=/var/delphix/server/db/force-reindex
 
+#
 # The perform-migration flag file is created by dx_execute prior rebooting into
 # Linux.
+#
 PERFORM_MIGRATION="/var/delphix/migration/perform-migration"
 
 function die() {
@@ -45,15 +48,26 @@ function perform_migration() {
 		die "Failed to chown /var/delphix/server"
 
 	zpool import -f domain0 || die "Failed to import domain0"
+	#
 	# domain0/mds is owned by delphix:staff on Illumos, and on Linux
 	# postgres can't access this dataset anymore. We change the permissions
 	# to the Linux defaults.
+	#
 	chown -R postgres:postgres /mds ||
 		die "Failed chowning /mds"
+
+	#
+	# DLPX-63949: Postgres must be re-indexed after migration.
+	# See dx_pg_post_start.sh for more info.
+	#
+	touch "$PG_REINDEX" || die "Failed to create $PG_REINDEX"
+	chown postgres "$PG_REINDEX" || die "Failed to chown $PG_REINDEX"
+
 	echo "$(date): Running migrate_config post-upgrade" \
 		>>"$MIGRATE_CONFIG_LOG"
-	"$MIGRATE_CONFIG_SCRIPT" post-upgrade >>"$MIGRATE_CONFIG_LOG" ||
-		die "Failed migrate_config post-upgrade"
+	"$MIGRATE_CONFIG_SCRIPT" post-upgrade >>"$MIGRATE_CONFIG_LOG" 2>&1 ||
+		die "Failed migrate_config post-upgrade, see" \
+			"$MIGRATE_CONFIG_LOG"
 	rm "$PERFORM_MIGRATION" || die "Failed to remove $PERFORM_MIGRATION"
 }
 


### PR DESCRIPTION
This change depends on an app-gate change: http://reviews.delphix.com/r/49164

**Unrelated change**
make sure that both stdout and stderr from migrate_config.py go into the migration log.

## TESTING

- Ran upgrade_minimal. Checked that it passes and made sure that re-indexing was triggered in postgres service logs: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/132/
- Ran full upgrade. Checked that the failure in the bug report wasn't reproduced anymore.  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/131/