### PR TITLE
DLPX-64194 Discard public ssh keys and user-data on external product variants

### DIFF
--- a/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
+++ b/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
@@ -16,8 +16,8 @@
 
 #
 # The configuration in this file has to be applied after 90_dpkg.cfg,
-# which is created by the cloud-init package's postinstall script.
-# Otherwise the value of 'datasource_list' set here will be reset.
+# which is created by the cloud-init package's postinstall script,
+# otherwise some of the configuration provided here can be overridden.
 #
 
 #
@@ -47,12 +47,6 @@ growpart:
   mode: off
 
 #
-# Disable all cloud-init datasources. We don't want to allow customers
-# to inject arbitrary code/users/etc. into the appliance.
-#
-datasource_list: [ None ]
-
-#
 # Disable cloud-init from manipulating the APT sources. We don't want
 # the Delphix appliance to rely on packages from any 3rd party sources
 # (e.g. Ubuntu's APT repositories), so we need to ensure cloud-init does
@@ -60,3 +54,12 @@ datasource_list: [ None ]
 #
 apt:
   preserve_sources_list: true
+
+#
+# By default, ignore ssh keys passed from the cloud management console.
+# Also, discard any user data to prevent tempering with the default
+# Delphix configuration. Note that those configurations are currently
+# only available on Delphix's version of cloud-init.
+#
+allow_public_ssh_keys: false
+allow_userdata: false


### PR DESCRIPTION
This leverages the changes introduced in https://github.com/delphix/cloud-init/pull/4.
Instead of disabling cloud-init all-together by default (by setting datasource_list to None), we selective disable user-data and public ssh keys passing.

### Related changes
cloud-init: https://github.com/delphix/cloud-init/pull/4
appliance-build: https://github.com/delphix/appliance-build/pull/290

## TESTING
- linux-pkg: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/50/
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1075/
- test that ssh keys are disabled on external-standard but not internal-dev. Also check logs output:
  ```
  internal-dev:
  $ grep allow_public_ssh_keys /var/log/cloud-init.log
  2019-05-17 15:10:59,740 - cc_ssh.py[DEBUG]: allow_public_ssh_keys = True: Public ssh keys consumed
  external-standard:
  $ grep allow_public_ssh_keys /var/log/cloud-init.log
  2019-05-17 15:39:59,868 - cc_ssh.py[DEBUG]: allow_public_ssh_keys = False: Public ssh keys discarded
  ```