### PR TITLE
Add "gdb" package dependency

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -92,6 +92,7 @@ DEPENDS += bcc-tools, \
 	   dstat, \
 	   emacs-nox, \
 	   ethtool, \
+	   gdb, \
 	   gdb-python, \
 	   glances, \
 	   htop, \


### PR DESCRIPTION
The "gdb-python" package has been modified to install its files into
"/opt/gdb-python" instead of "/" to prevent conflicts with the "gdb"
packages supplied by Ubuntu. Thus, we can now have both the Ubuntu "gdb"
package, and our custom "gdb-python" package, installed simultaneously.