### PR TITLE
disable spectre/meltdown/mds mitigations

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -22,6 +22,12 @@ GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 console=ttyS0,38400n8"
 GRUB_SERIAL_COMMAND="serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1"
 
 #
+# Disable Spectre/Meltdown/Foreshadow/MDS (Microarchitectural Data Sampling)
+# mitigations to increase performance.
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT mitigations=off"
+
+#
 # Disable IPv6 because it is not supported by the Delphix appliance. We
 # do so here, and not from systemd-sysctl, because while configuring
 # net.ipv6.conf.{default,all}.disable_ipv6 works for the currently


### PR DESCRIPTION
##### Disabling mitigations
    
Since the platform runs only trusted code, then we rely on the hypervisor
to mitigate any vulnerabilities. Cloud vendors have made the following
statements:
    
Azure:
> Microsoft has deployed mitigations across all our cloud services. The
> infrastructure that runs Azure and isolates customer workloads from each
> other is protected. This means that a potential attacker using the same
> infrastructure can’t attack your application using these vulnerabilities.
>     
> This Azure infrastructure update addresses the disclosed vulnerability at
> the hypervisor level and does not require an update to your Windows or
> Linux VM images. However, as always, you should continue to apply security
> best practices for your VM images.

    
AWS:
> AWS has designed and implemented its infrastructure with protections
> against these types of bugs, and has also deployed additional protections
> for MDS. All EC2 host infrastructure has been updated with these new
> protections, and no customer action is required at the infrastructure level.
>     
> All instances across the Amazon EC2 fleet are protected from all known
> instance-to-instance concerns of the CVEs previously listed. Instance-to-
> instance concerns assume an untrusted neighbor instance could read the
> memory of another instance or the AWS hypervisor. This issue has been
> addressed for AWS hypervisors, and no instance can read the memory of
> another instance, nor can any instance read AWS hypervisor memory. As
> we’ve stated, we haven’t observed meaningful performance impact for the
> overwhelming majority of EC2 workloads.

    
GCP:
> The host infrastructure that runs Compute Engine isolates customer
> workloads from each other. Unless you are running untrusted code inside
> your VMs, no further action is required.