### PR TITLE
Migration: use the by-id links when importing domain0 (except for aws)

### DIFF
--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -47,7 +47,20 @@ function perform_migration() {
 	chown -R root:root /var/delphix/server ||
 		die "Failed to chown /var/delphix/server"
 
-	zpool import -f domain0 || die "Failed to import domain0"
+	#
+	# In most cases, use the devices' by-id links to import domain0. This ensures
+	# persistent vdev names which can tolerate device reordering. AWS does not
+	# provide a by-id link, so we use simple device names (i.e. /dev/xvda)
+	#
+
+	BY_ID_LINK="/dev/disk/by-id"
+	if [[ -d "$BY_ID_LINK" ]]; then
+		zpool import -f -d $BY_ID_LINK domain0 ||
+			die "Failed to import domain0 by-id"
+	else
+		zpool import -f domain0 || die "Failed to import domain0"
+	fi
+
 	#
 	# domain0/mds is owned by delphix:staff on Illumos, and on Linux
 	# postgres can't access this dataset anymore. We change the permissions


### PR DESCRIPTION
When available, we should use the `by-id` links for device names when importing `domain0` after migration. This has to do with persistent `vdev` names allow for device reordering, etc. See DLPX-64115 for further motivation. This is part of a corresponding change in the `app-gate` which creates `domain0` and modifies the `vdevs` in `domain0` using these names. 

AWS does not provide a `by-dev` link, but I've confirmed that `esx`, `azure`, and `gcp` all do.  

Manually tested this on a platform that does have `by-id` links (ESX) and one that does not (AWS). Confirmed that migration works, `domain0` is correctly imported and the `vdevs` and be removed and readded as expected. 