### PR TITLE
DLPX-64434 Linux upgrade, error while unpacking upgrade image, unpack-image: image is corrupt

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -154,7 +154,7 @@ override_dh_install:
 	rm debian/tmp/var/lib/delphix-appliance/platform.in
 
 	./scripts/download-signature-key.sh upgrade 5.3 \
-		debian/tmp/var/lib/delphix-appliance/key-public.pem.upgrade.5.3
+		>debian/tmp/var/lib/delphix-appliance/key-public.pem.upgrade.5.3
 
 	dh_install --autodest "debian/tmp/*"
 


### PR DESCRIPTION
Missing `>` 😎 