### PR TITLE
Migrate masking data directory

### DIFF
--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -47,6 +47,13 @@ function perform_migration() {
 	chown -R root:root /var/delphix/server ||
 		die "Failed to chown /var/delphix/server"
 
+	if [[ -d /var/delphix/dmsuite ]]; then
+		mv -T /var/delphix/dmsuite /var/delphix/masking ||
+			die "Failed to move masking data directory"
+		chown -R masking:staff /var/delphix/masking ||
+			die "Failed to chown masking data directory"
+	fi
+
 	#
 	# In most cases, use the devices' by-id links to import domain0. This ensures
 	# persistent vdev names which can tolerate device reordering. AWS does not


### PR DESCRIPTION
The masking home directory has moved between 5.3 and 6.0 and this adds the necessary migration logic for that change. Also, since the id of the `staff` group has changed, it `chowns` the directory so that it is owned by `masking`/`staff`, as was on Illumos.