### PR TITLE
Add "delphix.target" to group all Delphix services

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -26,6 +26,7 @@ configure)
 	systemctl disable unattended-upgrades.service
 
 	systemctl enable auditd.service
+	systemctl enable delphix.target
 	systemctl enable delphix-migration.service
 	systemctl enable delphix-platform.service
 	systemctl enable systemd-networkd.service

--- a/debian/prerm
+++ b/debian/prerm
@@ -25,6 +25,7 @@ upgrade | remove)
 	# so we can't reliably restore the system back to that prior state.
 	#
 
+	systemctl disable delphix.target
 	systemctl disable delphix-migration.service
 	systemctl disable delphix-platform.service
 

--- a/files/common/lib/systemd/system/delphix-migration.service
+++ b/files/common/lib/systemd/system/delphix-migration.service
@@ -33,6 +33,7 @@
 #
 [Unit]
 Description=Delphix OS Migration Service
+PartOf=delphix.target
 DefaultDependencies=no
 After=systemd-udev-settle.service
 After=var-delphix.mount
@@ -52,4 +53,4 @@ RemainAfterExit=yes
 ExecStartPost=/bin/systemctl disable delphix-migration.service
 
 [Install]
-WantedBy=default.target
+WantedBy=delphix.target

--- a/files/common/lib/systemd/system/delphix-platform.service
+++ b/files/common/lib/systemd/system/delphix-platform.service
@@ -16,6 +16,7 @@
 
 [Unit]
 Description=Delphix Appliance Platform Service
+PartOf=delphix.target
 After=local-fs.target
 Before=rsync.service
 
@@ -41,4 +42,4 @@ Environment=DLPX_ANSIBLE_CONNECTION=local
 Environment=DLPX_ANSIBLE_INVENTORY=localhost,
 
 [Install]
-WantedBy=default.target
+WantedBy=delphix.target

--- a/files/common/lib/systemd/system/delphix.target
+++ b/files/common/lib/systemd/system/delphix.target
@@ -1,0 +1,40 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# We use this target as a convenient way to group all of our Delphix
+# services together, such that we can more easily check their status,
+# restart them, etc.
+#
+# For this to work properly, individual services must specify:
+#
+#     [Unit]
+#     PartOf=delphix.target
+#     [Install]
+#     WantedBy=delphix.target
+#
+# This way, when "delphix.target" is restarted, it will restart all our
+# Delphix services, without having to specify each one individually; we
+# accomplish this via the "PartOf" directive. Also, all enabled services
+# will be started, even if they happened to be "inactive" at the time;
+# accomplished via the "WantedBy" directive.
+#
+
+[Unit]
+Description=Delphix Appliance
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This change adds a new systemd target that will be used to group all of
our Delphix Appliance related services, to make it easy to restart all
services with a single command: "systemctl restart delphix.target"