### PR TITLE
DLPX-63558 update unpack-image script in Lumen to accept future wrapper upgrade image and hand-off to complete-unpack script

### DIFF
--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -42,7 +42,7 @@ function cleanup() {
 # the same version. Otherwise, this will fail if there's already an
 # unpacked image of the same version.
 #
-opt_f=false
+opt_f=""
 
 #
 # This option will skip the signature verification portion of this
@@ -50,7 +50,7 @@ opt_f=false
 # ensure the image hasn't been modified, but it can be useful for
 # development and/or testing purposes.
 #
-opt_s=false
+opt_s=""
 
 #
 # This option will cause this script to modify the "version.info" file,
@@ -60,7 +60,7 @@ opt_s=false
 # perhaps this otherwise would not have occurred; this is mostly useful
 # for internal testing of the "not-in-place" upgrade code paths.
 #
-opt_x=false
+opt_x=""
 
 while getopts ':fsx' c; do
 	case "$c" in
@@ -85,6 +85,7 @@ UPGRADE_IMAGE_PATH="$(readlink -f "$1")"
 [[ -n "$UPGRADE_IMAGE_PATH" ]] || die "unable to determine upgrade image path"
 
 trap cleanup EXIT
+
 UNPACK_DIR=$(mktemp -d -p "$UPDATE_DIR" -t unpack.XXXXXXX)
 [[ -d "$UNPACK_DIR" ]] || die "failed to create unpack directory '$UNPACK_DIR'"
 pushd "$UNPACK_DIR" &>/dev/null || die "'pushd $UNPACK_DIR' failed"
@@ -96,11 +97,11 @@ tar -xzf "$UPGRADE_IMAGE_PATH" ||
 
 report_progress_inc 40 "Verifying format."
 
-for file in SHA256SUMS payload.tar.gz version.info; do
+for file in SHA256SUMS prepare; do
 	[[ -f "$file" ]] || die "image is corrupt; missing '$file' file"
 done
 
-if ! $opt_s; then
+if [[ -z "$opt_s" ]]; then
 	openssl dgst -sha256 \
 		-verify /var/lib/delphix-appliance/key-public.pem.upgrade.5.3 \
 		-signature SHA256SUMS.sig.5.3 \
@@ -113,42 +114,12 @@ fi
 sha256sum -c SHA256SUMS >/dev/null ||
 	die "image is corrupt; checksums don't match"
 
-tar -xzf payload.tar.gz || die "failed to extract payload.tar.gz"
-rm payload.tar.gz || die "failed to remove payload.tar.gz"
-
-#
-# We need to be careful when sourcing this file, since it can conflict
-# with (and clobber) functions and/or variables previously defined.
-#
-# shellcheck disable=SC1091
-. version.info || die "sourcing version.info file failed"
-
-[[ -n "$VERSION" ]] || die "VERSION variable is empty"
-[[ -n "$MINIMUM_VERSION" ]] || die "MINIMUM_VERSION variable is empty"
-[[ -n "$MINIMUM_REBOOT_OPTIONAL_VERSION" ]] ||
-	die "MINIMUM_REBOOT_OPTIONAL_VERSION variable is empty"
-
-if $opt_x; then
-	sed -i \
-		"s/^\\(MINIMUM_REBOOT_OPTIONAL_VERSION\\)=.*$/\\1=$VERSION/" \
-		version.info ||
-		die "'sed -i ... version.info' failed"
-
-	# shellcheck disable=SC1091
-	. version.info || die "sourcing version.info file failed"
-fi
-
 popd &>/dev/null || die "'popd' failed"
 
-$opt_f && rm -rf "${UPDATE_DIR:?}/$VERSION" >/dev/null 2>&1
+report_progress_inc 50 "Handoff unpack to prepare script."
 
-[[ -d "$UPDATE_DIR/$VERSION" ]] && die "version $VERSION already exists"
-
-mv "$UNPACK_DIR" "$UPDATE_DIR/$VERSION" ||
-	die "failed to move unpacked upgrade image to $UPDATE_DIR/$VERSION"
-
-rm -f "$UPDATE_DIR/latest" || die "failed to remove 'latest' symlink"
-ln -s "$VERSION" "$UPDATE_DIR/latest" || die "failed to create 'latest' symlink"
+"$UNPACK_DIR"/prepare ${opt_f:+"-f"} ${opt_s:+"-s"} ${opt_x:+"-x"} "$UNPACK_DIR" ||
+	die "'prepare' hand-off failed"
 
 report_progress_inc 100 "Unpacking successful."
 


### PR DESCRIPTION
This review updates unpack-image to hand over unpack duties to a new prepare script (being added in PR https://github.com/delphix/appliance-build/pull/325) to complete the unpack. This design is necessary for SUV phase 2 since the structure of the upgrade image will change with the introduction of a new artifact - the verification package - outside of payload.tar.gz. This change in architecture at a future release (potentially 6.0.2.0) requires Lumen to have logic that can upgrade to versions with and without the updated architecture.

This hand-off design also gives us flexibility in introducing changes to the upgrade image as needed without having to roll-out such changes over multiple releases with prior releases having the necessary logic to handle the changes.

`Manual Tests:`
Manual test of unpacking a new upgrade image generated with the new prepare script using this unpack-image script was successful. 

```
tar -tvf internal-dev.upgrade.tar.gz 
-rw-r--r-- root/root       512 2019-06-25 00:05 SHA256SUMS.sig.5.3
-rw-r--r-- root/root       234 2019-06-25 00:05 SHA256SUMS
-rw-r--r-- root/root      2330 2019-06-25 00:05 version.info
-rwxrwxr-x 1000/1000      3939 2019-06-24 23:57 prepare
-rw-r--r-- root/root 3424779189 2019-06-25 00:05 payload.tar.gz

sudo ./unpack-image -f internal-dev.upgrade.tar.gz 
Progress increment: 19:06:44:697930129+0000, 10, Extracting upgrade image.
Progress increment: 19:08:00:434560383+0000, 40, Verifying format.
Progress increment: 19:08:21:353591869+0000, 50, Handoff unpack to prepare script.
Progress increment: 19:09:53:812158271+0000, 90, Prepare completed successfully.
Progress increment: 19:09:53:814707365+0000, 100, Unpacking successful.

cat /var/dlpx-update/latest/SHA256SUMS
3c36885ad57a1ec5ac3c4aa62593cf4dad565b8a16394a76f6b39b6c4b560b34  payload.tar.gz
f0517a5358422c707cd700fdafb784d3d558f9f1a089d3dcf849ab797f4bd88e  version.info
8ee737bc908ea6ae60344a34461462234f1837995fd2fa0c1100fcd653068e5a  prepare
```

`Automated Tests:`
git-ab-pre-push with updated parameter for appliance-build commit from PR https://github.com/delphix/appliance-build/pull/325 SUBMITTED : http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1517/

git ab-pre-push after https://github.com/delphix/appliance-build/pull/325 merged is CLEAN : http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1529/ 
vm: upgrade-testing-1739-8a5cd044.dlpxdc.co