### PR TITLE
DLPX-64428 prevent cloud-init from modifying ssh keys after first boot

### DIFF
--- a/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
+++ b/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
@@ -63,3 +63,10 @@ apt:
 #
 allow_public_ssh_keys: false
 allow_userdata: false
+
+#
+# Once keys in /etc/ssh are generated, we do not want to ever change
+# them anymore. By default, if cloud-init is reset or if a new instance
+# is detected, cloud-init will delete and re-generate ssh keys.
+#
+ssh_deletekeys: false

--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -130,7 +130,7 @@ rm payload.tar.gz || die "failed to remove payload.tar.gz"
 
 if $opt_x; then
 	sed -i \
-		"s/^\(MINIMUM_REBOOT_OPTIONAL_VERSION\)=.*$/\1=$VERSION/" \
+		"s/^\\(MINIMUM_REBOOT_OPTIONAL_VERSION\\)=.*$/\\1=$VERSION/" \
 		version.info ||
 		die "'sed -i ... version.info' failed"
 


### PR DESCRIPTION
This is a rework of http://reviews.delphix.com/r/49972, now that https://jira.delphix.com/browse/TOOL-7917 is fixed.

## Unrelated change
I have shellcheck 5.0.0 on my laptop and when I run `make check` it complains about:
```
In files/common/usr/bin/unpack-image line 133:
		"s/^\(MINIMUM_REBOOT_OPTIONAL_VERSION\)=.*$/\1=$VERSION/" \
                    ^-- SC1117: Backslash is literal in "\(". Prefer explicit escaping: "\\(".
                                                     ^-- SC1117: Backslash is literal in "\)". Prefer explicit escaping: "\\)".
                                                            ^-- SC1117: Backslash is literal in "\1". Prefer explicit escaping: "\\1".
```
Ubuntu has shellcheck 4.6.0 which doesn't catch this.

## Testing
- ab-pre-push --test-upgrade-from trunk: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1509/ (Note that upgrade failed due to https://jira.delphix.com/browse/DLPX-64827)
Testing upgrade for the shellcheck issue.
- Manually tested that ssh keys are different on 2 clones of the same AMI.
- Manually tested that ssh keys stay the same after resetting cloud init with `cloud-init clean -r`