### PR TITLE
Enable the operation of the NFS server without rpc.mountd

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -368,3 +368,26 @@
   with_items:
     - login
     - sshd
+
+#
+# The Delphix platform supports running as an NFSv4-only server, which
+# means that the services used by NFSv3 can be disabled (masked).
+# Unfortunately, the nfs-server unit contains a Requires dependency on
+# the nfs-mountd.service, preventing the nfs-mountd.service from being
+# masked without also preventing the nfs-server from starting. We
+# change this dependency to a Wants dependency so that if the service is
+# enabled, it will be available for NFSv3 configurations, but it can be
+# disabled for NFSv4 configurations.
+#
+- copy:
+    remote_src: yes
+    src: /lib/systemd/system/nfs-server.service
+    dest: /etc/systemd/system/nfs-server.service
+    owner: root
+    group: root
+    mode: 0644
+
+- replace:
+    path: /etc/systemd/system/nfs-server.service
+    regexp: '^Requires(=nfs-mountd.service)$'
+    replace: 'Wants\1'


### PR DESCRIPTION
This replaces the nfs-server.service's Requires depencency on the
nfs-mountd.service unit to a Wants dependency in order to enable
NFSv4-only operation (which doesn't require rpc.mountd). This change
does not configure the NFS server to run one protocol version or
another, but simply enables the server to be able to run without that
dependency for such a change to be possible in the future.

This is the first of a set of changes to enable an NFSv4-only configuration. Subsequent changes will be made to appliance-build to ship the out-of-the-box default NFSv4-only configuration, and then to dlpx-app-gate to dynamically switch between NFSv4-only or dual NFSv4-NFSv3 operation based on what VDBs are configured. Both of those changes will be dependent on this PR.

## Testing

git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1624/

Once that pre-push job finishes, I will clone a VM from the resulting image and verify that the dependency on nfs-mountd is correct.