### PR TITLE
CP-2777 CRA enabled for Linux

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -77,6 +77,11 @@ DEPENDS += python3-sh, \
 DEPENDS += delphix-buildinfo-userland,
 DEPENDS += delphix-buildinfo-kernel,
 
+#
+# The CRA PAM module provides an authentication method for the delphix user.
+#
+DEPENDS += pam-challenge-response,
+
 # Platform-specific dependencies
 DEPENDS.aws =
 DEPENDS.azure = walinuxagent,

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -394,3 +394,10 @@
   with_items:
     - login
     - sshd
+
+#
+# Enable CRA for external variants
+#
+- command: pam-auth-update --enable challenge-response
+  when:
+    - variant is regex("external-.*")


### PR DESCRIPTION
Enable CRA on external appliances during the ansible configuration on first boot, leveraging the recently-added `variant` variable.

Also, this change moves the dependency that gets the CRA PAM module installed from `delphix-virtualization` to `delphix-platform` (http://reviews.delphix.com/r/50896/diff removes it from `delphix-virtualization`).

ab pre-push run: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1652/flowGraphTable/