### PR TITLE
DLPX-63546 Deleting vdb with additional mount point provisioned from a staged dsource causes dsource stale filehandle

### DIFF
--- a/files/common/etc/systemd/system/nfs-server.service.d/override.conf
+++ b/files/common/etc/systemd/system/nfs-server.service.d/override.conf
@@ -1,0 +1,28 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Override the nfs-server service execution parameters. By default, the
+# service exports only filesystems in /etc/export and /etc/exports.d.
+# However, any filesystems exported via zfs won't exist in those
+# files and we must export "all" filesystems. We do this by changing
+# the Pre and Reload execution parameters.
+#
+[Service]
+ExecStartPre=
+ExecStartPre=/usr/sbin/exportfs -a
+ExecReload=
+ExecReload=/usr/sbin/exportfs -a


### PR DESCRIPTION
This change updates the `nfs-server.service` to run `exportfs` on all NFS mounts when it starts or restarts. This should ensure that mountpoints which are active don't receive ESTALE if the appstack ever restarts the nfs-server service.