### PR TITLE
Fix dataset mountpoint permissions post migration for NFSv4 exports

### DIFF
--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -85,6 +85,27 @@ function perform_migration() {
 		die "Failed chowning /mds"
 
 	#
+	# For each domain0 dataset with a default mountpoint,
+	# the parents need other-execute for NFSv4 exports.
+	#
+	echo "Fixing mountpoint permissions for domain0 datasets"
+	DATASETS=$(zfs list -H -r -t filesystem -o mountpoint domain0 |
+		grep ^/domain0/ | xargs dirname | sort | uniq)
+
+	for DATASET in $DATASETS; do
+		if [[ "$DATASET" == "/domain0" ]]; then
+			continue
+		fi
+		PERMS=$(stat "$DATASET" -c %a 2>/dev/null)
+		RETURN=$?
+		if [[ $RETURN -eq 0 && "$PERMS" == "750" ]]; then
+			echo "chmod o+x $DATASET"
+			chmod o+x "$DATASET" ||
+				die "Failed chmod o+x $DATASET"
+		fi
+	done
+
+	#
 	# DLPX-63949: Postgres must be re-indexed after migration.
 	# See dx_pg_post_start.sh for more info.
 	#


### PR DESCRIPTION
[DLPX-65118](https://jira.delphix.com/browse/DLPX-65118)
Added section to `os-migration` script to fix dataset permissions after a migration from illumos.  For each `domain0` dataset with a default mountpoint, the parents need other-execute for NFSv4 exports.

**Testing**
1. [ab-pre-push --test-upgrade-from 5.3.5.0](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1712/)
2. Manually tested the script that fixes the permissions on a migrated engine
3. Ran the `shellcheck` and `shfmtcheck` checks against the os-migration script
