### PR TITLE
rpc.nfsd ignores no-nfs-version parameter at reboot

### DIFF
--- a/files/common/etc/systemd/system/nfs-config.service.d/override.conf
+++ b/files/common/etc/systemd/system/nfs-config.service.d/override.conf
@@ -1,0 +1,23 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Override the nfs-config service post execution parameters. We add an
+# ExecStartPost operation to work around an NFS bug where a no-nfs-version
+# is ignored after a reboot.
+#
+[Service]
+ExecStartPost=/usr/lib/systemd/scripts/nfs-version-init.sh

--- a/files/common/usr/lib/systemd/scripts/nfs-version-init.sh
+++ b/files/common/usr/lib/systemd/scripts/nfs-version-init.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+
+#
+# Work around for kernel failing to parse the 'versions' input string
+# "-4.1 -4.2 -2 +3 +4" passed from rpc.nfsd after a reboot
+#
+# Prime the kernel version after a reboot to include +4 so that the -4.x works
+# Called by '/etc/systemd/system/nfs-config.service'
+#
+# We need this work-around until Ubuntu picks up nfs-utils 2.3.3
+#
+versions=$(cat /proc/fs/nfsd/versions)
+if [[ "$versions" == "-2 -3 -4 -4.0 -4.1 -4.2" ]]; then
+	printf "+4\n" >/proc/fs/nfsd/versions
+	echo "Initializing the NFS server version"
+fi
+
+exit 0


### PR DESCRIPTION
[DLPX-64900](https://jira.delphix.com/browse/DLPX-64900)

This is a work-around for a bug in `rpc.nfsd(8)` where it ignores the `--no-nfs-version 4.1` parameter after a reboot.  We must prime the kernel NFS `version` so that the input string to disable 4.1 and 4.2 succeeds.

**Testing**
1. [ab-pre-push](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1730/)
2. Confirmed that the generated `dlpx-master` VM had the two new files and that reboots persists the expected nfs version (-2 +3 +4 -4.1 -4.2)
3. Manually ran builds of `shellcheck` and `shfmtcheck` checks against the new script