### PR TITLE
Use Azure-specific paths when importing domain0

### DIFF
--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -63,10 +63,22 @@ function perform_migration() {
 		# In most cases, use the devices' by-id links to import
 		# domain0. This ensures persistent vdev names which can
 		# tolerate device reordering. AWS does not provide a by-id
-		# link, so we use simple device names (i.e. /dev/xvda)
+		# link, so we use simple device names (i.e. /dev/xvda). On
+		# Azure, however, we use the Azure-specific links, because the
+		# by-id links can change when the device is resized.
 		#
 		BY_ID_LINK="/dev/disk/by-id"
-		if [[ -d "$BY_ID_LINK" ]]; then
+		AZURE_LINK="/dev/disk/azure"
+		if [[ -d "$AZURE_LINK" ]]; then
+			dir_array=()
+			while read -r dir; do
+				dir_array+=(-d)
+				dir_array+=("$dir")
+			done < <(find "$AZURE_LINK" -maxdepth 1 -name "scsi*")
+			echo "zpool import -f ${dir_array[*]} domain0"
+			zpool import -f "${dir_array[@]}" domain0 ||
+				die "Failed to import domain0 by azure link"
+		elif [[ -d "$BY_ID_LINK" ]]; then
 			zpool import -f -d $BY_ID_LINK domain0 ||
 				die "Failed to import domain0 by-id"
 		else


### PR DESCRIPTION
On Azure, we want to use the azure-specific links to avoid issues where the by-id links change when the disk is expanded. Because there could be multiple `scsi` directories, we have to build a string that contains a `-d $dir` for each one when running the import command. This change is mutually dependent on the app-gate fix for DLPX-61215

Testing:
Migrated an engine from Illumos to Linux, verified that all disks (include rpool's disk) appear correctly configured. Verified that device removal/addition functioned after migration.