### PR TITLE
DLPX-64724 rtslib-fb-targetctl service should wait on domain0 zvol links before starting

### DIFF
--- a/files/common/lib/systemd/system/rtslib-fb-targetctl.service.d/override.conf
+++ b/files/common/lib/systemd/system/rtslib-fb-targetctl.service.d/override.conf
@@ -1,14 +1,9 @@
 [Unit]
 #
-# This service depends on zvol dev links to be present, which should
-# be implemented in DLPX-64724. In the meanwhile, we have this service
-# depend on zfs.target, which doesn't guarantee that the zvol links
-# will be there, but gives a time buffer after pools have been loaded
-# to create the zvol links. This new dependency is especially important
-# since local-fs.target, which this service depends on, no longer
-# depends on zfs-mount.service.
+# ZFS Volumes (zvols) must be ready when we start this service.
 #
-After=zfs.target
+Requires=zfs-volumes.target
+After=zfs-volumes.target
 
 #
 # During upgrade verification, the root filesystem will be booted as a

--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -118,6 +118,14 @@ function perform_migration() {
 	done
 
 	#
+	# Wait on zvol dev links to be ready.
+	# This must be done after we import domain0 and before we attempt
+	# to start the rtslib-fb-targetctl service, which depends on the
+	# current service.
+	#
+	zvol_wait || die "Failed waiting on zvol dev links."
+
+	#
 	# DLPX-63949: Postgres must be re-indexed after migration.
 	# See dx_pg_post_start.sh for more info.
 	#


### PR DESCRIPTION
This leverages the functionality added in https://github.com/zfsonlinux/zfs/pull/8975.

## Testing
ab-pre-push + migration testing: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1836/