### PR TITLE
DLPX-65276 Create new dataset that will be shared across versions to store rollback and verify logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ debian/debhelper-build-stamp
 debian/delphix-platform-*
 debian/files
 debian/tmp
+
+#IntelliJ IDEA adds the below files
+delphix-platform.iml
+.idea/

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -126,6 +126,25 @@
   when: not ansible_is_chroot
 
 #
+# Create the directory and ZFS dataset that we'll use to store upgrade
+# related logs (that need to be shared across versions). This directory is
+# used  part of upgrade verify and rollback process to share log files to
+# older version. Thus, we need to be careful if/when changing this, as we'll
+# need to coordinate the change with the appliance-build upgrade-scripts.
+#
+- file:
+    path: /var/tmp/delphix-upgrade
+    state: directory
+
+- zfs:
+    name: rpool/upgrade-logs
+    state: present
+    extra_zfs_properties:
+      mountpoint: /var/tmp/delphix-upgrade
+      compression: gzip
+  when: not ansible_is_chroot
+
+#
 # Configure command audit logging
 #
 # We want to record all commands executed on the appliance. Opt out for


### PR DESCRIPTION
Problem: During upgrade if we decide to rollback, we need to collect the logs and place it in a location that can be accessed from the older location.

Solution: Create a new dataset that will be shared across versions. Place the rollback logs there.

git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1920/