### PR TITLE
DLPX-65674 cron job to clean up 'delphix-upgrade' directory is stale

### DIFF
--- a/files/common/etc/cron.daily/delphix-upgrade-logs
+++ b/files/common/etc/cron.daily/delphix-upgrade-logs
@@ -14,6 +14,6 @@ find /var/tmp/delphix-upgrade -type f -mtime +7 -delete
 
 #
 # After the old files have been deleted, we need to remove any empty
-# directories, excluding "/var/log/delphix-upgrade" itself.
+# directories, excluding "/var/tmp/delphix-upgrade" itself.
 #
 find /var/tmp/delphix-upgrade -mindepth 1 -type d -mtime +7 -empty -delete

--- a/files/common/etc/cron.daily/delphix-upgrade-logs
+++ b/files/common/etc/cron.daily/delphix-upgrade-logs
@@ -10,10 +10,10 @@
 # and removed before they consume storage space to the point of causing
 # capacity problems on the root filesystem and/or root pool.
 #
-find /var/log/delphix-upgrade -type f -mtime +7 -delete
+find /var/tmp/delphix-upgrade -type f -mtime +7 -delete
 
 #
 # After the old files have been deleted, we need to remove any empty
 # directories, excluding "/var/log/delphix-upgrade" itself.
 #
-find /var/log/delphix-upgrade -mindepth 1 -type d -mtime +7 -empty -delete
+find /var/tmp/delphix-upgrade -mindepth 1 -type d -mtime +7 -empty -delete


### PR DESCRIPTION
Changed cron job directory from "/var/log/delphix-upgrade" to "/var/tmp/delphix-upgrade",
testing still tbd