### PR TITLE
Upgrade image file is better left uncompressed

### DIFF
--- a/files/common/usr/bin/download-latest-image
+++ b/files/common/usr/bin/download-latest-image
@@ -56,8 +56,8 @@ aws s3 cp \
 	"s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/appliance-build/master/post-push/latest" \
 	. || die "failed to download file: 'latest'"
 
-$opt_f && rm -f "$1.upgrade.tar.gz" >/dev/null 2>&1
-[[ -f "$1.upgrade.tar.gz" ]] && die "image $1.upgrade.tar.gz already exists"
+$opt_f && rm -f "$1.upgrade.tar" >/dev/null 2>&1
+[[ -f "$1.upgrade.tar" ]] && die "image $1.upgrade.tar already exists"
 
-aws s3 cp "s3://snapshot-de-images/$(cat latest)/upgrade-artifacts/$1.upgrade.tar.gz" . ||
-	die "failed to download file: '$1.upgrade.tar.gz'"
+aws s3 cp "s3://snapshot-de-images/$(cat latest)/upgrade-artifacts/$1.upgrade.tar" . ||
+	die "failed to download file: '$1.upgrade.tar'"

--- a/files/common/usr/bin/get-property-from-image
+++ b/files/common/usr/bin/get-property-from-image
@@ -60,8 +60,8 @@ IMAGE="$1"
 PROPERTY="$2"
 
 case "$IMAGE" in
-*.upgrade.tar.gz) ;;
-*) die "The upgrade image must be a '.upgrade.tar.gz' file" ;;
+*.upgrade.tar) ;;
+*) die "The upgrade image must be a '.upgrade.tar' file" ;;
 esac
 
 UPGRADE_IMAGE_PATH="$(readlink -f "$IMAGE")"
@@ -73,7 +73,7 @@ UNPACK_DIR=$(mktemp -d -p "$UPDATE_DIR" -t unpack.XXXXXXX)
 [[ -d "$UNPACK_DIR" ]] || die "failed to create unpack directory '$UNPACK_DIR'"
 pushd "$UNPACK_DIR" &>/dev/null || die "'pushd $UNPACK_DIR' failed"
 
-tar -z -x SHA256SUMS SHA256SUMS.sig.5.3 version.info -f "$UPGRADE_IMAGE_PATH" ||
+tar -x SHA256SUMS SHA256SUMS.sig.5.3 version.info -f "$UPGRADE_IMAGE_PATH" ||
 	die "failed to extract files from upgrade image '$UPGRADE_IMAGE_PATH'"
 
 for file in SHA256SUMS SHA256SUMS.sig.5.3 version.info; do

--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -79,8 +79,8 @@ shift $((OPTIND - 1))
 IMAGE="$1"
 
 case "$IMAGE" in
-*.upgrade.tar.gz) ;;
-*) die "The upgrade image must be a '.upgrade.tar.gz' file" ;;
+*.upgrade.tar) ;;
+*) die "The upgrade image must be a '.upgrade.tar' file" ;;
 esac
 
 UPGRADE_IMAGE_PATH="$(readlink -f "$IMAGE")"
@@ -94,7 +94,7 @@ pushd "$UNPACK_DIR" &>/dev/null || die "'pushd $UNPACK_DIR' failed"
 
 report_progress_inc 10 "Extracting upgrade image."
 
-tar -xzf "$UPGRADE_IMAGE_PATH" ||
+tar -xf "$UPGRADE_IMAGE_PATH" ||
 	die "failed to extract upgrade image '$UPGRADE_IMAGE_PATH'"
 
 report_progress_inc 40 "Verifying format."


### PR DESCRIPTION
The upgrade image file will no longer be compressed, so this change
updates the necessary scripts that interact with that file, such that
they will work with this new file format.