### PR TITLE
LX-1897 migration: make sure sharenfs is not set on any dataset after migration

### DIFF
--- a/files/common/usr/lib/systemd/scripts/nfs-version-init.sh
+++ b/files/common/usr/lib/systemd/scripts/nfs-version-init.sh
@@ -14,7 +14,7 @@
 #
 versions=$(cat /proc/fs/nfsd/versions)
 if [[ "$versions" == "-2 -3 -4 -4.0 -4.1 -4.2" ]]; then
-	printf "+4\n" >/proc/fs/nfsd/versions
+	printf "+4\\n" >/proc/fs/nfsd/versions
 	echo "Initializing the NFS server version"
 fi
 

--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -75,17 +75,37 @@ function perform_migration() {
 				dir_array+=(-d)
 				dir_array+=("$dir")
 			done < <(find "$AZURE_LINK" -maxdepth 1 -name "scsi*")
-			echo "zpool import -f ${dir_array[*]} domain0"
-			zpool import -f "${dir_array[@]}" domain0 ||
+			echo "zpool import -fN ${dir_array[*]} domain0"
+			zpool import -fN "${dir_array[@]}" domain0 ||
 				die "Failed to import domain0 by azure link"
 		elif [[ -d "$BY_ID_LINK" ]]; then
-			zpool import -f -d $BY_ID_LINK domain0 ||
+			echo "zpool import -fN -d $BY_ID_LINK domain0"
+			zpool import -fN -d $BY_ID_LINK domain0 ||
 				die "Failed to import domain0 by-id"
 		else
-			zpool import -f domain0 ||
+			echo "zpool import -fN domain0"
+			zpool import -fN domain0 ||
 				die "Failed to import domain0"
 		fi
 	fi
+
+	#
+	# sharenfs is set when a dataset (VDB/dSource) is shared and is
+	# cleared when it is stopped or quiesced. At this point in time,
+	# this property will only be set for datasets that failed to be
+	# quiesced before the upgrade reboot. The sharenfs setting was
+	# set on Illumos with options specific to Illumos and targetting
+	# an NFS version that may be different on Linux. As such, attempting
+	# to migrate it could result in unexpected behaviour, so we clear
+	# it instead. We rely on the user to manually restart any VDBs that
+	# failed to quiesce.
+	#
+	echo "clearing sharenfs properties"
+	zfs inherit -r sharenfs domain0 ||
+		die "failed to clear sharenfs properties"
+
+	echo "mounting ZFS file-systems"
+	zfs mount -a || die "Failed to mount zfs file-systems"
 
 	#
 	# domain0/mds is owned by delphix:staff on Illumos, and on Linux


### PR DESCRIPTION
This makes sure any datasets that were still shared when migrating from Illumos will be unshared. We need this since we'll be switching from NFSv3 to NFSv4 for most datasets and the Illumos sharenfs arguments are not compatible with Linux anyway.

## Testing
migration run: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2030/