### PR TITLE
DLPX-65853 nfs-kernel-server - failed to init nfsdcltrack database

### DIFF
--- a/files/common/etc/systemd/system/nfs-config.service.d/override.conf
+++ b/files/common/etc/systemd/system/nfs-config.service.d/override.conf
@@ -16,8 +16,9 @@
 
 #
 # Override the nfs-config service post execution parameters. We add an
-# ExecStartPost operation to work around an NFS bug where a no-nfs-version
-# is ignored after a reboot.
+# ExecStartPost operation to work around NFS server bugs:
+#  1. the no-nfs-version is ignored after a reboot.
+#  2. nfs-kernel-server - failed to init nfsdcltrack database 
 #
 [Service]
-ExecStartPost=/usr/lib/systemd/scripts/nfs-version-init.sh
+ExecStartPost=/usr/lib/systemd/scripts/nfs-server-prep.sh

--- a/files/common/usr/lib/systemd/scripts/nfs-server-prep.sh
+++ b/files/common/usr/lib/systemd/scripts/nfs-server-prep.sh
@@ -18,4 +18,20 @@ if [[ "$versions" == "-2 -3 -4 -4.0 -4.1 -4.2" ]]; then
 	echo "Initializing the NFS server version"
 fi
 
+#
+# DLPX-65853
+# Due to a permissions error, where '/var/lib/nfs' is owned by statd, the
+# database used by nfsdcltrack(8) is never initialized.  This database is
+# necessary for the NFSv4 server to track clients and notify them when the
+# server is restarted.
+#
+# The work around is to create the directory that holds the client tracking
+# database upfront.
+#
+NFSD_CL_TRACK_DIR="/var/lib/nfs/nfsdcltrack"
+
+if [[ ! -d "$NFSD_CL_TRACK_DIR" ]]; then
+	mkdir "$NFSD_CL_TRACK_DIR" && echo Creating dir for fsdcltrack database
+fi
+
 exit 0


### PR DESCRIPTION
**Description**
Due to a permissions error, where `'/var/lib/nfs'` is owned by `statd`, the database used by `nfsdcltrack(8)` is never initialized.  The kernel nfs server code invokes `/sbin/nfsdcltrack` to initialize the database, which in turn fails when trying to make the containing `nfsdcltrack` directory.

This database is necessary for the NFSv4 server to track clients and notify them when the server is restarted.  The work around is to create the directory that holds the client tracking database upfront.

**Testing**

Manually tested the work around to confirm that the database is initialized.

ab-pre-push results:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2069/
