### PR TITLE
Don't use "-q" when building Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - TARGET=shfmtcheck
 
 install:
-  - docker build -qt delphix-platform:latest docker
+  - docker build -t delphix-platform:latest docker
 
 script:
   - ./scripts/docker-run.sh make $TARGET


### PR DESCRIPTION
We've been seeing timeouts when building the Docker container used with
our TravisCI testing. If a command doesn't produce any output for 10
minutes, TravisCI will fail the build the command is running in. Thus,
if "docker build" takes longer than 10 minutes to build the image, our
builds would fail because we had been using the "-q" option when
building the image.

This change removes the "-q" option so that the "docker build" command
will output text as it builds the image, and this output will keep
TravisCI happy even if it takes more than 10 minutes to build the image.