### PR TITLE
DLPX-65330 Latest public keys are missing in upgrade and migration images

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,6 +22,8 @@ KERNEL_TYPE.esx := generic
 KERNEL_TYPE.gcp := gcp
 KERNEL_TYPE.kvm := kvm
 
+DELPHIX_SIGNATURE_TYPES = registration upgrade
+
 #
 # The following meta-package consolidates all the kernel packages required
 # by the Delphix Appliance for a given platform. Note that delphix-kernel
@@ -166,8 +168,9 @@ override_dh_install:
 		>debian/tmp/var/lib/delphix-appliance/platform
 	rm debian/tmp/var/lib/delphix-appliance/platform.in
 
-	./scripts/download-signature-key.sh upgrade 5.3 \
-		>debian/tmp/var/lib/delphix-appliance/key-public.pem.upgrade.5.3
+	for type in $(DELPHIX_SIGNATURE_TYPES) ; do \
+		./scripts/download-signature-key.sh $$type "$(DELPHIX_SIGNATURE_VERSION)" \
+		>"debian/tmp/var/lib/delphix-appliance/key-public.pem.$$type.$(DELPHIX_SIGNATURE_VERSION)" ; done
 
 	dh_install --autodest "debian/tmp/*"
 

--- a/files/common/usr/bin/get-appliance-version
+++ b/files/common/usr/bin/get-appliance-version
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o errexit
+set -o pipefail
+
+zfs get -Hpo value \
+	"com.delphix:current-version" \
+	"$(dirname "$(zfs list -Hpo name /)")" | tr -d '\n'

--- a/files/common/usr/bin/get-property-from-image
+++ b/files/common/usr/bin/get-property-from-image
@@ -80,21 +80,23 @@ UNPACK_DIR=$(mktemp -d -p "$UPDATE_DIR" -t unpack.XXXXXXX)
 [[ -d "$UNPACK_DIR" ]] || die "failed to create unpack directory '$UNPACK_DIR'"
 pushd "$UNPACK_DIR" &>/dev/null || die "'pushd $UNPACK_DIR' failed"
 
-tar -x SHA256SUMS SHA256SUMS.sig.5.3 version.info -f "$UPGRADE_IMAGE_PATH" ||
+DELPHIX_SIGNATURE_VERSION=$(/usr/bin/get-appliance-version | cut -d - -f 1 | cut -d . -f 1-2)
+
+tar -x SHA256SUMS SHA256SUMS.sig."$DELPHIX_SIGNATURE_VERSION" version.info -f "$UPGRADE_IMAGE_PATH" ||
 	die 14 "failed to extract files from upgrade image '$UPGRADE_IMAGE_PATH'"
 
-for file in SHA256SUMS SHA256SUMS.sig.5.3 version.info; do
+for file in SHA256SUMS SHA256SUMS.sig."$DELPHIX_SIGNATURE_VERSION" version.info; do
 	[[ -f "$file" ]] || die 15 "image is corrupt; missing '$file' file"
 done
 
 if [[ -z "$opt_s" ]]; then
 	openssl dgst -sha256 \
-		-verify /var/lib/delphix-appliance/key-public.pem.upgrade.5.3 \
-		-signature SHA256SUMS.sig.5.3 \
+		-verify /var/lib/delphix-appliance/key-public.pem.upgrade."$DELPHIX_SIGNATURE_VERSION" \
+		-signature SHA256SUMS.sig."$DELPHIX_SIGNATURE_VERSION" \
 		SHA256SUMS >/dev/null ||
 		die 16 "image is corrupt; verification of 'SHA256SUMS' file," \
-			"using signature 'SHA256SUMS.sig.5.3'" \
-			"and key 'key-public.pem.upgrade.5.3' failed"
+			"using signature 'SHA256SUMS.sig.$DELPHIX_SIGNATURE_VERSION'" \
+			"and key 'key-public.pem.upgrade.$DELPHIX_SIGNATURE_VERSION' failed"
 fi
 
 awk '$2 == "version.info" { print $0 }' SHA256SUMS |

--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -110,14 +110,16 @@ for file in SHA256SUMS prepare; do
 	[[ -f "$file" ]] || die 15 "image is corrupt; missing '$file' file"
 done
 
+DELPHIX_SIGNATURE_VERSION=$(/usr/bin/get-appliance-version | cut -d - -f 1 | cut -d . -f 1-2)
+
 if [[ -z "$opt_s" ]]; then
 	openssl dgst -sha256 \
-		-verify /var/lib/delphix-appliance/key-public.pem.upgrade.5.3 \
-		-signature SHA256SUMS.sig.5.3 \
+		-verify /var/lib/delphix-appliance/key-public.pem.upgrade."$DELPHIX_SIGNATURE_VERSION" \
+		-signature SHA256SUMS.sig."$DELPHIX_SIGNATURE_VERSION" \
 		SHA256SUMS >/dev/null ||
 		die 16 "image is corrupt; verification of 'SHA256SUMS' file," \
-			"using signature 'SHA256SUMS.sig.5.3'" \
-			"and key 'key-public.pem.upgrade.5.3' failed"
+			"using signature 'SHA256SUMS.sig.$DELPHIX_SIGNATURE_VERSION'" \
+			"and key 'key-public.pem.upgrade.$DELPHIX_SIGNATURE_VERSION' failed"
 fi
 
 sha256sum -c SHA256SUMS >/dev/null ||

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -47,6 +47,7 @@ $DOCKER_RUN --rm \
 	--env AWS_SECRET_ACCESS_KEY \
 	--env DELPHIX_SIGNATURE_URL \
 	--env DELPHIX_SIGNATURE_TOKEN \
+	--env DELPHIX_SIGNATURE_VERSION \
 	--volume "$TOP:/opt/delphix-platform" \
 	--workdir "/opt/delphix-platform" \
 	delphix-platform "$@"

--- a/scripts/download-signature-key.sh
+++ b/scripts/download-signature-key.sh
@@ -30,11 +30,6 @@ fi
 set -o errexit
 set -o pipefail
 
-if [[ -z "$1" ]] || [[ -z "$2" ]]; then
-	echo "Must specify key 'type' and 'version'."
-	exit 1
-fi
-
 TYPE="$1"
 VERSION="$2"
 
@@ -46,7 +41,13 @@ VERSION="$2"
 # package will not be correct. When this package is built by our build
 # system and automation, these variables should be available.
 #
-if [[ -n "${DELPHIX_SIGNATURE_TOKEN:-}" ]] && [[ -n "${DELPHIX_SIGNATURE_URL:-}" ]]; then
+if [[ -n "${DELPHIX_SIGNATURE_TOKEN:-}" ]] &&
+	[[ -n "${DELPHIX_SIGNATURE_URL:-}" ]] &&
+	[[ -n "${DELPHIX_SIGNATURE_VERSION:-}" ]]; then
+	if [[ -z "$TYPE" ]] || [[ -z "$VERSION" ]]; then
+		echo "Must specify key 'type' and 'version'."
+		exit 1
+	fi
 	curl -s -S -u "$DELPHIX_SIGNATURE_TOKEN" \
 		"$DELPHIX_SIGNATURE_URL/$TYPE/keyVersion/$VERSION" |
 		jq -Mr .publicKey


### PR DESCRIPTION
These changes install the correct image signing keys (both `registration` and `upgrade` keys) for the correct/current Delphix Release version being built.
The signing keys version to use is parameterized via `DELPHIX_SIGNATURE_VERSION` which is passed as environment variable via jenkins build job -> linux-pkg -> delphix_platform package build.  Corresponding jenkins changes are: [devops-gate ](http://reviews.delphix.com/r/52325/)