### PR TITLE
DLPX-66029 migration: network config should be migrated as early as possible

### DIFF
--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -43,6 +43,18 @@ function perform_migration() {
 	__trigger_unset_stress_option \
 		"STRESS_MIGRATION_FAIL_BEGIN_MIGRATION_SERVICE"
 
+	__trigger_unset_stress_option \
+		"STRESS_MIGRATION_FAIL_BEFORE_MIGRATE_CONFIG"
+
+	echo "$(date): Running migrate_config post-upgrade" \
+		>>"$MIGRATE_CONFIG_LOG"
+	"$MIGRATE_CONFIG_SCRIPT" post-upgrade >>"$MIGRATE_CONFIG_LOG" 2>&1 ||
+		die "Failed migrate_config post-upgrade, see" \
+			"$MIGRATE_CONFIG_LOG"
+
+	__trigger_unset_stress_option \
+		"STRESS_MIGRATION_FAIL_AFTER_MIGRATE_CONFIG"
+
 	echo "chown -R /var/delphix/server"
 	chown -R root:root /var/delphix/server ||
 		die "Failed to chown /var/delphix/server"
@@ -168,18 +180,6 @@ function perform_migration() {
 	#
 	touch "$PG_REINDEX" || die "Failed to create $PG_REINDEX"
 	chown postgres "$PG_REINDEX" || die "Failed to chown $PG_REINDEX"
-
-	__trigger_unset_stress_option \
-		"STRESS_MIGRATION_FAIL_BEFORE_MIGRATE_CONFIG"
-
-	echo "$(date): Running migrate_config post-upgrade" \
-		>>"$MIGRATE_CONFIG_LOG"
-	"$MIGRATE_CONFIG_SCRIPT" post-upgrade >>"$MIGRATE_CONFIG_LOG" 2>&1 ||
-		die "Failed migrate_config post-upgrade, see" \
-			"$MIGRATE_CONFIG_LOG"
-
-	__trigger_unset_stress_option \
-		"STRESS_MIGRATION_FAIL_AFTER_MIGRATE_CONFIG"
 
 	rm "$PERFORM_MIGRATION" || die "Failed to remove $PERFORM_MIGRATION"
 }


### PR DESCRIPTION
To finalize the migration of the network configuration, in the delphix-migration service we call `migrate_config.py post-upgrade`.

The issue is that we call this after a bunch of other steps. If those other steps fail, then we'd be potentially left with an unconfigured network. If the Delphix Engine was configured with a static IP then this would leave networking unconfigured (although cloud-init would then kick-in and configure it with DHCP if possible). In any case, it would be better to configure networking properly as soon as possible to facilitate debugging in case of issues in the delphix-migration service.

## Testing
- migration: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2111
- Palash tested this change with delphix-migration stress options.