### PR TITLE
Configure kdump so that makedumpfile excludes ZFS ARC file data pages

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2019 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -445,3 +445,11 @@
 - command: pam-auth-update --enable challenge-response
   when:
     - variant is regex("external-.*")
+
+#
+# Configure kdump so that makedumpfile excludes ZFS ARC file data pages
+#
+- lineinfile:
+    path: /etc/default/kdump-tools
+    regexp: '^#?MAKEDUMP_ARGS='
+    line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"'


### PR DESCRIPTION
**Testing**
ab-pre-push:  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2128/
	
Confirmed that the VM generated from the above build has the correct `MAKEDUMP_ARGS` setting in `/etc/default/kdump-tools`

**Message Level**
Also update the message level to get a report summary of the makedumpfile in the console, as in:
```
[   53.755074] kdump-tools[765]: STEP [Checking for memory holes  ] : 0.020981 seconds
[   53.771909] kdump-tools[765]: STEP [Excluding unnecessary pages] : 0.120571 seconds
[   53.781250] kdump-tools[765]: STEP [Copying data               ] : 35.703359 seconds
[   53.797194] kdump-tools[765]: STEP [Copying data               ] : 0.000087 seconds
[   53.823060] kdump-tools[765]: Original pages  : 0x00000000001e1afa
[   53.838617] kdump-tools[765]:   Excluded pages   : 0x00000000001af512
[   53.854644] kdump-tools[765]:     Pages filled with zero  : 0x0000000000008e04
[   53.868321] kdump-tools[765]:     Non-private cache pages : 0x000000000000fcbf
[   53.876450] kdump-tools[765]:     Private cache pages     : 0x0000000000000000
[   53.881304] kdump-tools[765]:     private filter pages : 0x00000000000e8e83
[   53.886908] kdump-tools[765]:     User process data pages : 0x0000000000066cc6
[   53.892910] kdump-tools[765]:     Free pages              : 0x0000000000046f06
[   53.898820] kdump-tools[765]:     Hwpoison pages          : 0x0000000000000000
[   53.903437] kdump-tools[765]:   Remaining pages  : 0x00000000000325e8
[   53.908382] kdump-tools[765]:   (The number of pages is reduced to 10%.)
[   53.913762] kdump-tools[765]: Memory Hole     : 0x000000000005e506
[   53.918952] kdump-tools[765]: --------------------------------------------------
[   53.928676] kdump-tools[765]: Total pages     : 0x0000000000240000
[   53.933915] kdump-tools[765]: Cache hit: 349466, miss: 935, hit rate: 99.7%
```