### PR TITLE
Various improvements to allow migration stress testing in the mgmt stack

### DIFF
--- a/files/common/usr/bin/migrationctl
+++ b/files/common/usr/bin/migrationctl
@@ -18,6 +18,7 @@
 import argparse
 import os
 import sys
+import time
 
 import sh
 
@@ -82,6 +83,14 @@ class Service:
             return False
 
     def start(self):
+        #
+        # If the service has failed and the restart counter reached its
+        # limit we must first reset the counter.
+        #
+        if self.is_failed():
+            if not self._command('reset-failed'):
+                warning('"systemctl reset-failed" failed for service %s'
+                        % self.name)
         started = self._command('start')
         if started and self.state != 'active':
             warning('Service %s start succeeded but state is %s'
@@ -133,6 +142,7 @@ class Service:
 class Migration:
     PERFORM_MIGRATION = '/var/delphix/migration/perform-migration'
     MIGRATION_CHECK_DIR = '/var/delphix/migration/illumos-config'
+    MIGRATION_COMPLETED = '/var/delphix/migration/migration-completed'
 
     def __init__(self):
         Migration.system_check()
@@ -158,22 +168,14 @@ class Migration:
             error("System doesn't come from Illumos")
             sys.exit(1)
 
-    def check_if_reboot_after_migration(self):
-        #
-        # After a successful run of delphix-migration, the service is
-        # disabled, so it will be inactive on reboot.
-        #
-        if self.svc_migration.is_inactive() and \
-                not os.path.exists(Migration.PERFORM_MIGRATION):
-            return True
-        return False
+    @staticmethod
+    def get_mgmt_upgrade_stage():
+        root_dataset = sh.zfs('list', '-H', '-o', 'name', '/').strip()
+        root_container = os.path.dirname(root_dataset)
+        return sh.zfs('get', '-H', '-o', 'value', 'com.delphix:mgmt_upgrade',
+                      root_container).strip()
 
     def status(self):
-        if self.check_if_reboot_after_migration():
-            print('System rebooted after a successful run of %s.'
-                  % self.svc_migration)
-            sys.exit(0)
-
         Service.print_header()
         for service in self.services:
             service.pretty_print_state()
@@ -194,16 +196,19 @@ class Migration:
                 print('Migration is in progress, please wait.')
                 break
 
-        for service in self.services:
-            if not service.is_active():
-                break
+        mgmt_upgrade_stage = Migration.get_mgmt_upgrade_stage()
+        if mgmt_upgrade_stage != '-':
+            print(Color.yellow('delphix-mgmt upgrade has not yet completed. '
+                               'Stage: %s.' % mgmt_upgrade_stage))
+
+        if os.path.exists(Migration.MIGRATION_COMPLETED):
+            print(Color.green('Migration has completed.'))
         else:
-            print(Color.green('Migration was successful.'))
+            print(Color.yellow('Migration has not yet completed.'))
 
     def resume(self):
-        if self.check_if_reboot_after_migration():
-            print('System rebooted after a successful run of %s.'
-                  % self.svc_migration)
+        if os.path.exists(Migration.MIGRATION_COMPLETED):
+            print('Migration has been already completed')
             sys.exit(0)
 
         if self.svc_migration.is_active():
@@ -229,7 +234,13 @@ class Migration:
             if not run_service(service):
                 sys.exit(1)
 
-        success('Migration completed')
+        print('All migration-related services have started.')
+
+        if not os.path.exists(Migration.MIGRATION_COMPLETED):
+            warning('mgmt service started but migration completed flag '
+                    'has not been set.')
+        else:
+            success('Migration completed')
 
 def error(text):
     print(Color.red('Error: ' + text))
@@ -254,6 +265,21 @@ def run_service(service):
     started = service.start()
     if started:
         success('Service %s started' % service)
+        return True
+
+    service.refresh()
+    if service.is_activating():
+        warning('Service %s failed to start, but current state is '
+                '"activating". The auto-restarter probably kicked-in. '
+                'Waiting for service to settle...' % service)
+
+    while service.is_activating():
+        time.sleep(3)
+        service.refresh()
+
+    started = service.is_active()
+    if started:
+        success('Service %s started on a subsequent attempt' % service)
     else:
         error('Service %s failed to start' % service)
         print('Run "sudo journalctl -u %s" to find out more' % service)

--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -18,6 +18,7 @@
 MIGRATE_CONFIG_SCRIPT="/opt/delphix/migration/migrate_config.py"
 MIGRATE_CONFIG_LOG="/var/delphix/migration/log"
 PG_REINDEX=/var/delphix/server/db/force-reindex
+MGMT_SERVICE_OVERRIDE="/run/systemd/system/delphix-mgmt.service.d/override.conf"
 
 # shellcheck disable=SC1091
 . /opt/delphix/server/bin/upgrade/dx_upg_stress_options --source
@@ -180,6 +181,23 @@ function perform_migration() {
 	#
 	touch "$PG_REINDEX" || die "Failed to create $PG_REINDEX"
 	chown postgres "$PG_REINDEX" || die "Failed to chown $PG_REINDEX"
+
+	#
+	# Prevent the mgmt service from restarting on failure for the duration
+	# of migration as this makes debugging and migration stress testing
+	# harder.
+	#
+	mkdir -p "$(dirname "$MGMT_SERVICE_OVERRIDE")" ||
+		die "Failed to create dir $(dirname "$MGMT_SERVICE_OVERRIDE")"
+	cat <<-EOF >"$MGMT_SERVICE_OVERRIDE" ||
+		#
+		# Set temporarily by delphix-migration service.
+		#
+		[Service]
+		Restart=no
+	EOF
+		die "Failed to create delphix-mgmt.service override file."
+	systemctl daemon-reload || die "daemon-reload failed"
 
 	rm "$PERFORM_MIGRATION" || die "Failed to remove $PERFORM_MIGRATION"
 }


### PR DESCRIPTION
We add a new "migration complete" flag file that is set by the mgmt stack
when the migration upgrade is completed. This simplifies the logic in
migrationctl to determine when all migration steps are completed.

migrationctl resume functionality is improved to take into account services
that are auto-restarted on failure. Note that this doesn't apply to the mgmt
stack as auto-restart functionality is now disabled in the mgmt stack for
the duration of migration; this makes stress testing easier and also
improves the debugging experience by avoiding restarting multiple times on
the same failures.

## Dependencies
depends on app-gate: http://reviews.delphix.com/r/52562/
related appliance-build: https://github.com/delphix/appliance-build/pull/362

## Testing
See app-gate review. 
