### PR TITLE
Sporadic failures when loading the crash kernel in low memory due to KASLR

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -37,8 +37,58 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT ipv6.disable=1"
 
 #
 # Increase the amount of memory reserved for the crash kernel.
-# Empirically, it seems we need about 512M to get it to boot. If the
-# system has less than 1G, disable crash dumps rather than reserving
-# half of memory for the crash kernel.
 #
-GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=1024M-:512M"
+# Empirically, it seems we need about 512M to get it to boot so
+# supplying something like "crashkernel=512M" in the cmdline
+# provided by GRUB to the OS would suffice.
+#
+# Unfortunately, given our current kernel (v4.15 at the time of this
+# writing) the system would try to allocate a contiguous chunk out
+# of low memory (the first 896MBs of it to be specific). This works
+# well most of the time except from the cases when KASLR places the
+# running kernel in that region making it impossible for the system
+# to find a contiguous 512MB chunk for the crash kernel.
+#
+# This behavior has been fixed in newer versions of the kernel but
+# as we are stuck in the current version for now we are left with
+# the following workaround: We split the 512M allocation to two
+# chunks, one within the 896MB window of low memory and one in high
+# memory. Using high memory for the whole reservation would be ideal
+# but certain types of allocations from the crash kernel can only
+# happen in low memory. As a result we are forced to split this
+# chunk to a low memory and a high memory part.
+#
+# The tradeoff in sizing the low memory segment is the following:
+# - The smaller the low memory segment, the higher the probability
+#   of it finding a free contiguous block for its size in the first
+#   896MB of memory and thus the probability that the crash kernel
+#   will be loaded. This also allows more memory to be used in
+#   userspace allocations in the crash kernel.
+# - The bigger the low memory segment, the smaller the chances of
+#   the crash kernel running out of kernel memory and becoming
+#   unresponsive.
+#
+# In both extreme scenarios the worst-case is the same. The system
+# becomes unresponsive either because it panicked and there was no
+# crash kernel to load, or because the crash kernel did load but
+# got stuck as it ran out of memory. Splitting the 512MB segment
+# in the middle (256MB for each chunk) empirically seems to not
+# cause any problems.
+#
+# Side Note:
+# We have a testing/debugging use case in appliance-build where we
+# load up an image on QEMU using 1GB of RAM or less. For this use
+# case the system will boot normally but the crash kernel will fail
+# to load, so generating crash dumps on panic is not expected to
+# work for such systems.
+#
+# Patches in newer kernel versions relevant to this issue:
+# [1] X86/kdump: move crashkernel=X to reserve under 4G by default
+#     LKML: https://lkml.org/lkml/2019/4/20/229
+#     Upstream commit: 9ca5c8e632ce8f144ec6d00da2dc5e16b41d593c
+# [2] X86/kdump: fall back to reserve high crashkernel memory
+#     LKML: https://lkml.org/lkml/2019/4/20/230
+#     Upstream commit: b9ac3849af412fd3887d7652bdbabf29d2aecc16
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=256M,high"
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=256M,low"


### PR DESCRIPTION
### Commit Description

On our current kernel version (v4.15) the reservation for the
crash kernel is done within the first 896MB of memory by default
in one contiguous chunk. This is problematic for us because we
currently need 512MB for our crash kernel which not only is pretty
big for such a small window but also the allocation is guaranteed
to fail whenever the running kernel (not the crash kernel) is
randomly placed within that window by KASLR.

This patch splits the reservation for the crash kernel into two
parts with one of them being in high memory (e.g. outside the
required region of the first 896MBs). This provides more
flexibility on how we can size it and making the allocations for
the reservation more likely to succeed.

For more background info on the actual bug refer to DLPX-65761.
For more background info on the design of this refer to the
block comment of this patch.

### Testing

QA (still running):
I reproduced the issue with David Mendez's scripts a couple of times.
Then applied the changes seen in this patch and ran them again, the
issue didn't come up after the scripts were running for 12+ hours (the script is still running so I can update that number again).

git ab-pre-push:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2205/

manual:
Logged into a running VM that was running dx-test as part of the ab-pre-push above.
```
$ dmesg | grep crash
[    0.000000] Command line: BOOT_IMAGE=/ROOT/delphix.QRTO3O2/root@/boot/vmlinuz-4.15.0-1050-aws root=ZFS=rpool/ROOT/delphix.QRTO3O2/root ro console=tty0 console=ttyS0,38400n8 mitigations=off ipv6.disable=1 crashkernel=256M,high crashkernel=256M,low
[    0.000000] Reserving 256MB of low memory at 3584MB for crashkernel (System low RAM: 3839MB)
[    0.000000] Reserving 256MB of memory at 8176MB for crashkernel (System RAM: 8191MB)
[    0.000000] Kernel command line: BOOT_IMAGE=/ROOT/delphix.QRTO3O2/root@/boot/vmlinuz-4.15.0-1050-aws root=ZFS=rpool/ROOT/delphix.QRTO3O2/root ro console=tty0 console=ttyS0,38400n8 mitigations=off ipv6.disable=1 crashkernel=256M,high crashkernel=256M,low
```
```
$ sudo cat /proc/iomem  | grep Crash
  e0000000-efffffff : Crash kernel
  1ff000000-20effffff : Crash kernel
```

### Other notes

1. Assuming this commit makes it in, I have a change ready for the appliance-build repo to change the migration scripts with the same numbers:
```
--- a/live-build/misc/migration-scripts/dx_apply
+++ b/live-build/misc/migration-scripts/dx_apply
@@ -279,7 +279,8 @@ LX_CMDLINE=(
        "root=ZFS=$RPOOL/ROOT/$FSNAME/root"
        'console=tty0 console=ttyS0,115200n8'
        'ipv6.disable=1'
-       'crashkernel=1024M-:512M'
+       'crashkernel=256M,high'
+       'crashkernel=256M,low'
        'zfsforce=1'
        'mitigations=off'
 )
```

2. I have a note for two future items on this. The first one is now that we are more acquainted with how the crash kernel works, we can boot into it and start figuring out why it needs so much memory. The second thing is that once we start building our own kernels, we should be able to patch the relevant code to loosen up (or even completely get rid of) the whole splitting memory tradeoff.