### PR TITLE
DLPX-36241 Version List Not Updated After Uploading Upgrade Version

### DIFF
--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -133,4 +133,8 @@ return=$?
 
 report_progress_inc 100 "Unpacking successful."
 
+if [[ $(systemctl is-active delphix-mgmt.service) == "active" ]]; then
+	su sysadmin -c "system version" >/dev/null
+fi
+
 exit 0


### PR DESCRIPTION
**Solution**: 
Check if the management stack is active. If so, pass the `system version` command along to the CLI to trigger an upgrade version list refresh. This will cause the UI to update the version list after an upgrade image is uploaded using the command line tool `unpack-image`.