### PR TITLE
DLPX-66005 Unquiesced VDBs cause domain0 to fail to mount due to a bug in zfs inherit sharenfs

### DIFF
--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -113,6 +113,13 @@ function perform_migration() {
 	__trigger_unset_stress_option \
 		"STRESS_MIGRATION_FAIL_AFTER_DOMAIN0_IMPORT"
 
+	#
+	# Note that we must mount the ZFS datasets before clearing sharenfs
+	# as calling after sometimes fails (see DLPX-66005 for more info).
+	#
+	echo "mounting ZFS file-systems"
+	zfs mount -a || die "Failed to mount zfs file-systems"
+
 	__trigger_unset_stress_option \
 		"STRESS_MIGRATION_FAIL_AFTER_ZFS_MOUNT"
 
@@ -130,9 +137,6 @@ function perform_migration() {
 	echo "clearing sharenfs properties"
 	zfs inherit -r sharenfs domain0 ||
 		die "failed to clear sharenfs properties"
-
-	echo "mounting ZFS file-systems"
-	zfs mount -a || die "Failed to mount zfs file-systems"
 
 	#
 	# domain0/mds is owned by delphix:staff on Illumos, and on Linux


### PR DESCRIPTION
zfs inherit sharenfs automatically mounts each dataset which has
sharenfs set. However the parent datasets will not be mounted if
they do not have sharenfs set, which will result in the creation
of mount directories in the wrong file systems and will later
cause zfs mount -a to fail with "directory not empty". As a
work around to that bug, we make sure to call zfs mount -a first.

## Testing
- migration: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2221/
- manually tested migration with VDBs that failed to quiesce and verified that migration completed properly.