### PR TITLE
Remove glances package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -109,7 +109,6 @@ DEPENDS += bcc-tools, \
 	   ethtool, \
 	   gdb, \
 	   gdb-python, \
-	   glances, \
 	   htop, \
 	   iftop, \
 	   inotify-tools, \


### PR DESCRIPTION
This package provides a neat terminal UI for monitoring various aspects of a system, but it pulls in about 80MB of dependencies and the information it provides can be obtained through other means.