### PR TITLE
DLPX-66652 [Backport of Issue DLPX-66267 to 6.0.0.0] SSH service stops listening to external sources after reboot

### DIFF
--- a/files/common/lib/systemd/system/ssh.service.d/override.conf
+++ b/files/common/lib/systemd/system/ssh.service.d/override.conf
@@ -6,4 +6,9 @@
 # (e.g. if an unrelated service failed), as well as enable users to log
 # into the system as quickly as possible after a reboot.
 #
+# We add a single dependency on network.target to ensure that any addresses
+# listed as ListenAddress options in /etc/ssh/sshd_config are configured before
+# sshd starts because sshd will need to bind explicitly to each.
+#
 DefaultDependencies=no
+After=network.target


### PR DESCRIPTION
The root-cause of this bug is that the ssh systemd service doesn't have
a dependency on network interface configuration.

By default, when using DHCP, the sshd daemon listens on the unspecified
address (0.0.0.0). When the system is configured with static IP
addresses, however, each address gets included individually as
"ListenAddress" directives in /etc/ssh/sshd_config. This results in sshd
binding to and listening on each address individually. If, at startup,
the addresses listed there are not configured, sshd will fail to bind to
them, and will not listen for connections to those addresses. When that
happens, we can see sshd output errors in the ssh service journal:

 -- Reboot --
Oct 01 22:39:37 localhost sshd[604]: Server listening on 127.0.0.1 port 22.
Oct 01 22:39:37 localhost sshd[604]: error: Bind to port 22 on 10.43.42.64 faile

The fix is to have the ssh service depend on the network.target systemd unit.