### PR TITLE
DLPX-66227 Disk I/O scheduler should be `noop` rather than default `cfq`

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -36,6 +36,12 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT mitigations=off"
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT ipv6.disable=1"
 
 #
+# On Delphix appliance, disks should have 'noop' I/O scheduler since they
+# would be under ZFS control.
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT elevator=noop"
+
+#
 # Increase the amount of memory reserved for the crash kernel.
 #
 # Empirically, it seems we need about 512M to get it to boot so


### PR DESCRIPTION
Disk should have `noop` I/O scheduler for optimal performance since ZFS will schedule I/Os.