### PR TITLE
DLPX-67597 [Backport of Issue DLPX-67583 to 6.0.0.0] migration: floppy driver sometimes causes system to hang on boot on 5.0 kernel

### DIFF
--- a/files/common/etc/modprobe.d/blacklist-floppy.conf
+++ b/files/common/etc/modprobe.d/blacklist-floppy.conf
@@ -1,0 +1,9 @@
+#
+# ADDED BY DELPHIX
+#
+# The floppy driver is buggy in the 5.0.0 kernel and sometimes causes the
+# system to hang at boot time or later. We do not use floppy devices in Linux
+# but systems that migrated from Illumos may have a floppy device present.
+# See DLPX-67583 for more info.
+#
+blacklist floppy


### PR DESCRIPTION
Clean cherry-pick
## Testing
migration on ESX: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2551/