### PR TITLE
Disable Ubuntu motd banner and provide a Delphix-specific one.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -25,6 +25,28 @@ configure)
 
 	systemctl disable unattended-upgrades.service
 
+	#
+	# We need to make sure that the motd-news.service is disabled. This
+	# service reaches out to a public Ubuntu news service over the public
+	# Internet to cache dynamic content that is then optionally printed by
+	# /etc/update-motd.d/50-motd-news. There are at least three problems
+	# with this:
+	#
+	# 1. We don't want engines in customer environments reaching out to
+	#    public services.
+	# 2. We don't care about the dynamic content provided by Ubuntu.
+	# 3. The service explicitly runs the /etc/update-motd.d/50-motd-news
+	#    script and fails if that script isn't executable, and we
+	#    turn off all executable bits on files in this directory except
+	#    those supplied by Delphix to suppress non-Delphix motd messages.
+	#
+	# As such, the service needs to be disable, which involves both the
+	# service unit along with the timer unit that is tasked with running it
+	# every 12 hours.
+	#
+	systemctl disable motd-news.service
+	systemctl disable motd-news.timer
+
 	systemctl enable auditd.service
 	systemctl enable delphix.target
 	systemctl enable delphix-migration.service

--- a/files/common/etc/update-motd.d/00-delphix
+++ b/files/common/etc/update-motd.d/00-delphix
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 full_version=$(/usr/bin/get-appliance-version)
-version=$(echo $full_version | awk -F'-' '{print $1}')
-build=$(echo $full_version | sed 's/.*-\(.*\)+.*/\1/')
+version=$(echo "$full_version" | awk -F'-' '{print $1}')
+build=$(echo "$full_version" | sed 's/.*-\(.*\)+.*/\1/')
 
 printf "Welcome to Delphix %s (%s)\n" "$version" "$build"

--- a/files/common/etc/update-motd.d/00-delphix
+++ b/files/common/etc/update-motd.d/00-delphix
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+full_version=$(/usr/bin/get-appliance-version)
+version=$(echo $full_version | awk -F'-' '{print $1}')
+build=$(echo $full_version | sed 's/.*-\(.*\)+.*/\1/')
+
+printf "Welcome to Delphix %s (%s)\n" "$version" "$build"

--- a/files/common/etc/update-motd.d/00-delphix
+++ b/files/common/etc/update-motd.d/00-delphix
@@ -1,7 +1,4 @@
 #!/bin/sh
 
-full_version=$(/usr/bin/get-appliance-version)
-version=$(echo "$full_version" | awk -F'-' '{print $1}')
-build=$(echo "$full_version" | sed 's/.*-\(.*\)+.*/\1/')
-
-printf "Welcome to Delphix %s (%s)\n" "$version" "$build"
+version=$(/usr/bin/get-appliance-version | awk -F'+' '{print $1}')
+printf "Welcome to Delphix %s\n" "$version"

--- a/files/common/etc/update-motd.d/00-delphix
+++ b/files/common/etc/update-motd.d/00-delphix
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-version=$(/usr/bin/get-appliance-version | awk -F'+' '{print $1}')
+version=$(get-appliance-version | awk -F'+' '{print $1}')
 printf "Welcome to Delphix %s\n" "$version"

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -478,3 +478,16 @@
     path: /etc/default/kdump-tools
     regexp: '^#?MAKEDUMP_ARGS='
     line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"'
+
+#
+# Disable all motd scripts except for those provided by Delphix
+#
+- find:
+    paths: /etc/update-motd.d
+    excludes: '*-delphix*'
+  register: motd_files
+
+- file:
+    path: "{{ item.path }}"
+    mode: 0644
+  with_items: '{{ motd_files.files }}'

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -480,9 +480,9 @@
     line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"'
 
 #
-# Disable all motd scripts except for those provided by Delphix. We start by
-# removing executable permissions on every script in /etc/update-motd.d except
-# those that have "-delphix" in their filename.
+# Disable all motd scripts except for those provided by Delphix by removing
+# executable permissions on every script in /etc/update-motd.d except those
+# that have "-delphix" in their filename.
 #
 - find:
     paths: /etc/update-motd.d
@@ -493,24 +493,3 @@
     path: "{{ item.path }}"
     mode: 0644
   with_items: '{{ motd_files.files }}'
-
-#
-# We also need to make sure that the motd-news.service never runs. This
-# service reaches out to a public Ubuntu news service over the public
-# Internet to cache dynamic content that is then optionally printed by
-# /etc/update-motd.d/50-motd-news. There are at least three problems with
-# this:
-#
-# 1. We don't want engines in customer environments reaching out to
-#    public services.
-# 2. We don't care about the dynamic content provided by Ubuntu.
-# 3. The service explicitly runs the /etc/update-motd.d/50-motd-news script
-#    and fails if that script isn't executable (we disable the executable
-#    bit on it above).
-#
-# As such, the service needs to be disable/masked, which involves both
-# the service unit along with the timer unit that is tasked with running
-# it every 12 hours.
-#
-- command: systemctl mask motd-news.service
-- command: systemctl mask motd-news.timer

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -178,7 +178,7 @@
 # would end up causing important messages from less verbose services to
 # be flushed and lost prematurely.
 #
-- shell: systemctl mask systemd-journald-audit.socket
+- command: systemctl mask systemd-journald-audit.socket
 
 #
 # By default, the ulimit for core files is set to 0, and the default
@@ -480,7 +480,9 @@
     line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"'
 
 #
-# Disable all motd scripts except for those provided by Delphix
+# Disable all motd scripts except for those provided by Delphix. We start by
+# removing executable permissions on every script in /etc/update-motd.d except
+# those that have "-delphix" in their filename.
 #
 - find:
     paths: /etc/update-motd.d
@@ -491,3 +493,24 @@
     path: "{{ item.path }}"
     mode: 0644
   with_items: '{{ motd_files.files }}'
+
+#
+# We also need to make sure that the motd-news.service never runs. This
+# service reaches out to a public Ubuntu news service over the public
+# Internet to cache dynamic content that is then optionally printed by
+# /etc/update-motd.d/50-motd-news. There are at least three problems with
+# this:
+#
+# 1. We don't want engines in customer environments reaching out to
+#    public services.
+# 2. We don't care about the dynamic content provided by Ubuntu.
+# 3. The service explicitly runs the /etc/update-motd.d/50-motd-news script
+#    and fails if that script isn't executable (we disable the executable
+#    bit on it above).
+#
+# As such, the service needs to be disable/masked, which involves both
+# the service unit along with the timer unit that is tasked with running
+# it every 12 hours.
+#
+- command: systemctl mask motd-news.service
+- command: systemctl mask motd-news.timer


### PR DESCRIPTION
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2577/

Before:
```
guild login: sysadmin
Password:
Welcome to Ubuntu 18.04.3 LTS (GNU/Linux 5.0.0-36-generic x86_64)
 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage
 * Overheard at KubeCon: "microk8s.status just blew my mind".
     https://microk8s.io/docs/commands#microk8s.status
 * Canonical Livepatch is available for installation.
   - Reduce system reboots and improve kernel security. Activate at:
     https://ubuntu.com/livepatch
The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.
Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.
guild.dc1>
```
After:
```
guild login: sysadmin
Password:
Last login: Mon Dec  9 16:01:40 UTC 2019 on ttyS0
Welcome to Delphix 6.1.0.0-snapshot.20191127042627846
guild.dc1>
```