### PR TITLE
Disable Ubuntu motd banner and provide a Delphix-specific one.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -25,6 +25,28 @@ configure)
 
 	systemctl disable unattended-upgrades.service
 
+	#
+	# We need to make sure that the motd-news.service is disabled. This
+	# service reaches out to a public Ubuntu news service over the public
+	# Internet to cache dynamic content that is then optionally printed by
+	# /etc/update-motd.d/50-motd-news. There are at least three problems
+	# with this:
+	#
+	# 1. We don't want engines in customer environments reaching out to
+	#    public services.
+	# 2. We don't care about the dynamic content provided by Ubuntu.
+	# 3. The service explicitly runs the /etc/update-motd.d/50-motd-news
+	#    script and fails if that script isn't executable, and we
+	#    turn off all executable bits on files in this directory except
+	#    those supplied by Delphix to suppress non-Delphix motd messages.
+	#
+	# As such, the service needs to be disable, which involves both the
+	# service unit along with the timer unit that is tasked with running it
+	# every 12 hours.
+	#
+	systemctl disable motd-news.service
+	systemctl disable motd-news.timer
+
 	systemctl enable auditd.service
 	systemctl enable delphix.target
 	systemctl enable delphix-migration.service

--- a/files/common/etc/update-motd.d/00-delphix
+++ b/files/common/etc/update-motd.d/00-delphix
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+version=$(get-appliance-version | awk -F'+' '{print $1}')
+printf "Welcome to Delphix %s\n" "$version"

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -178,7 +178,7 @@
 # would end up causing important messages from less verbose services to
 # be flushed and lost prematurely.
 #
-- shell: systemctl mask systemd-journald-audit.socket
+- command: systemctl mask systemd-journald-audit.socket
 
 #
 # By default, the ulimit for core files is set to 0, and the default
@@ -478,3 +478,18 @@
     path: /etc/default/kdump-tools
     regexp: '^#?MAKEDUMP_ARGS='
     line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"'
+
+#
+# Disable all motd scripts except for those provided by Delphix by removing
+# executable permissions on every script in /etc/update-motd.d except those
+# that have "-delphix" in their filename.
+#
+- find:
+    paths: /etc/update-motd.d
+    excludes: '*-delphix*'
+  register: motd_files
+
+- file:
+    path: "{{ item.path }}"
+    mode: 0644
+  with_items: '{{ motd_files.files }}'


### PR DESCRIPTION
This is a clean cherry-pick of the same change on the master branch (see https://github.com/delphix/delphix-platform/pull/170).

This fix disables the Ubuntu-provided motd banner and replaces it with a
simple Delphix-specific banner. It also disables the motd-news systemd
service that dynamically fetches news from a public Internet service.