### PR TITLE
DLPX-67782 migration: Failed to import domain0 on i3.4xlarge in AWS

### DIFF
--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -20,6 +20,7 @@ MIGRATE_CONFIG_LOG="/var/delphix/migration/log"
 PG_REINDEX=/var/delphix/server/db/force-reindex
 MGMT_SERVICE_OVERRIDE="/run/systemd/system/delphix-mgmt.service.d/override.conf"
 POSTGRES_SERVICE_OVERRIDE="/run/systemd/system/delphix-postgres@default.service.d/override.conf"
+PLATFORM_TYPE=$(cat /var/lib/delphix-appliance/platform)
 
 # shellcheck disable=SC1091
 . /opt/delphix/server/bin/upgrade/dx_upg_stress_options --source
@@ -92,7 +93,7 @@ function perform_migration() {
 		#
 		BY_ID_LINK="/dev/disk/by-id"
 		AZURE_LINK="/dev/disk/azure"
-		if [[ -d "$AZURE_LINK" ]]; then
+		if [[ "$PLATFORM_TYPE" == "azure" && -d "$AZURE_LINK" ]]; then
 			dir_array=()
 			while read -r dir; do
 				dir_array+=(-d)
@@ -101,7 +102,7 @@ function perform_migration() {
 			echo "zpool import -fN ${dir_array[*]} domain0"
 			zpool import -fN "${dir_array[@]}" domain0 ||
 				die "Failed to import domain0 by azure link"
-		elif [[ -d "$BY_ID_LINK" ]]; then
+		elif [[ "$PLATFORM_TYPE" != "aws" && -d "$BY_ID_LINK" ]]; then
 			echo "zpool import -fN -d $BY_ID_LINK domain0"
 			zpool import -fN -d $BY_ID_LINK domain0 ||
 				die "Failed to import domain0 by-id"


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
https://jira.delphix.com/browse/DLPX-67782

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Now, we will attempt to use `by-id` links when importing after migration only if this is a non AWS platform and there are `by-id` links present. 

I tested this on AWS instances both with and without NVMes (`t2` and `i3`) and on ESX and confirmed that import after migration works fine. 

git-ab-pre-push --test-upgrade-from 5.3.7.0: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2601/

git-ab-pre-push --test-upgrade-from 5.3.7.0 -p esx:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2689/
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
