### PR TITLE
DLPX-68014 iSCSI service interruption during deferred upgrade

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -49,9 +49,16 @@ configure)
 
 	systemctl enable auditd.service
 	systemctl enable delphix.target
-	systemctl enable delphix-migration.service
 	systemctl enable delphix-platform.service
 	systemctl enable systemd-networkd.service
+
+	#
+	# Only enable the delphix-migration service on initial install, not
+	# on upgrade.
+	#
+	if [[ -z "$2" ]]; then
+		systemctl enable delphix-migration.service
+	fi
 
 	if ! id -u postgres >/dev/null; then
 		# When installing postgres, a postgres user is created unless it

--- a/files/common/lib/systemd/system/delphix-migration.service
+++ b/files/common/lib/systemd/system/delphix-migration.service
@@ -49,7 +49,6 @@
 #
 [Unit]
 Description=Delphix OS Migration Service
-PartOf=delphix.target
 DefaultDependencies=no
 After=systemd-udev-settle.service
 After=cloud-init-local.service
@@ -88,7 +87,7 @@ RemainAfterExit=yes
 ExecStartPost=/bin/systemctl disable --no-reload delphix-migration.service
 
 [Install]
-WantedBy=delphix.target
+WantedBy=default.target
 
 #
 # By Setting RequiredBy dependencies in the Install section, this enforces


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Issue Number: DLPX-68014
The current behaviour is that the rtslib-fb-targetctl service restarts during a deferred upgrade, causing iSCSI-based VDBs to be inaccessible for a certain time. 

## What is the new behavior?

The new behaviour is that rtslib-fb-targetctl is not restarted on upgrade anymore.

This is achieved with 2 changes:
1. We do not re-enable the delphix-migration service when we upgrade the delphix-platform package.
2. We remove delphix-migration as a part of delphix.target.
Either one of those changes should be theoretically sufficient to prevent this bug, but we are doing them both since that is the correct behaviour for this service.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Testing
- manually upgraded delphix-platform and restarted `delphix.target`. Verified that delphix-migration.service was not re-enabled and that rtslib-fb-targetctl.service was not restarted.
- ab-pre-push (testing upgrade): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2687/
- migration: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2686/