### PR TITLE
DLPX-68065 [Backport of DLPX-68055 to 6.0.0.0] Can Login with delphix user password instead of using CRA Token

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -467,7 +467,10 @@
 #
 # Enable CRA for external variants
 #
-- command: pam-auth-update --enable challenge-response
+- command: pam-auth-update {{ item }}
+  with_items:
+  - --enable challenge-response
+  - --remove unix
   when:
     - variant is regex("external-.*")
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: DLPX-68055

On Linux (but not illumos), entering the "shark" password at the CRA response prompt lets the user in.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When CRA is enabled, disable the `unix` PAM module which does password-based authentication.


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
App gate review is http://reviews.delphix.com/r/55215/

appliance build pre-push from delphix-platform and linking to that app gate change is running: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2712/flowGraphTable/

Will verify that the generated external image does not have the bug anymore, and will verify that the internal image continues to work as usual.