### PR TITLE
DLPX-67909 Traceroute command/package is missing

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -137,6 +137,7 @@ DEPENDS += bcc-tools, \
 	   jq, \
 	   kdump-tools, \
 	   makedumpfile-dbgsym, \
+	   mtr, \
 	   libkdumpfile, \
 	   libkdumpfile-dbgsym, \
 	   lsof, \
@@ -161,6 +162,7 @@ DEPENDS += bcc-tools, \
 	   sysstat, \
 	   tmux, \
 	   trace-cmd, \
+	   traceroute, \
 	   tshark, \
 	   vim
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ X] Build was run locally and any changes were pushed
- [ X] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: DLPX-67909


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This introduces two new networking diagnostic tools -- traceroute and mtr.

## Does this introduce a breaking change?

- [ ] Yes
- [ X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2729/

Traceroute output:
```
% traceroute google.com
traceroute to google.com (216.58.194.174), 30 hops max, 60 byte packets
 1  _gateway (10.43.0.1)  8.931 ms  8.936 ms  8.920 ms
 2  172.16.123.12 (172.16.123.12)  0.200 ms  0.197 ms  0.189 ms
 3  6-1-19.ear1.sanjose1.level3.net (4.15.123.65)  0.806 ms  1.191 ms  1.564 ms
 4  ae-2-7.edge1.sanjose3.level3.net (4.69.209.169)  0.883 ms  0.775 ms  0.763 ms
 5  72.14.223.91 (72.14.223.91)  1.118 ms  1.103 ms  1.041 ms
 6  108.170.242.81 (108.170.242.81)  1.423 ms  1.579 ms  1.412 ms
 7  108.170.237.21 (108.170.237.21)  1.600 ms  1.466 ms  1.520 ms
 8  sfo07s13-in-f14.1e100.net (216.58.194.174)  1.463 ms  1.600 ms  1.496 ms
```
mtr:
```
%mtr google.com
                             My traceroute  [v0.92]
gwilson-mtr.dcenter (10.43.14.190)                     2020-01-20T06:27:02-0800
Keys:  Help   Display mode   Restart statistics   Order of fields   quit
                                       Packets               Pings
 Host                                Loss%   Snt   Last   Avg  Best  Wrst StDev
 1. _gateway                          0.0%     5    1.6   1.7   0.9   4.1   1.4
 2. 172.16.123.12                     0.0%     5    5.3   1.2   0.1   5.3   2.3
 3. 6-1-19.ear1.sanjose1.level3.net   0.0%     5    0.5   2.0   0.5   7.2   2.9
 4. ae-2-7.edge1.sanjose3.level3.net  0.0%     5    0.8   0.8   0.8   0.9   0.0
 5. 72.14.223.91                      0.0%     5    1.0   1.0   0.8   1.7   0.4
 6. 108.170.242.81                    0.0%     5    1.4   1.5   1.4   1.5   0.0
 7. 108.170.237.21                    0.0%     5    1.5   1.5   1.5   1.6   0.0
 8. sfo07s13-in-f14.1e100.net         0.0%     5    1.5   1.5   1.5   1.5   0.0
```
