### PR TITLE
DLPX-68141 [Backport of Issue DLPX-68025 to 6.0.1.0] migration: clearing sharenfs on domain0 datasets takes a long time

### DIFF
--- a/files/common/var/lib/delphix-platform/clear-sharenfs
+++ b/files/common/var/lib/delphix-platform/clear-sharenfs
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+import subprocess
+
+lines = subprocess.check_output(
+    "zfs list -t filesystem -r -H -o name,sharenfs,mounted domain0",
+    shell=True).decode('utf-8').splitlines()
+datasets = [line.split('\t') for line in lines]
+#
+# Filter out datasets with sharenfs == "off" and sharenfs == "-"
+#
+datasets = [ds for ds in datasets if ds[1] not in ('off', '-')]
+
+#
+# List all datasets that have sharenfs property source set to "local".
+# Those are the datasets for which we explicitly set the sharenfs property.
+# By default, datasets have sharenfs property source set to "default", meaning
+# that they inherit whatever value is set on their parent. Therefore we
+# filter out all datasets that do not have sharenfs source set to local since
+# their sharenfs setting will be updated automatically.
+#
+sharenfs_local = subprocess.check_output(
+    "zfs get -r -t filesystem -o name -Hs local sharenfs domain0",
+    shell=True).decode('utf-8').splitlines()
+datasets = [ds for ds in datasets if ds[0] in sharenfs_local]
+
+#
+# We only clear sharenfs for datasets that are mounted as in some cases
+# zfs can mount datasets while clearing their sharenfs property and mount
+# children without mounting the parent datasets first. Given that ZFS
+# automatically creates directories for mountpoints, mounting children
+# before the parents would end up creating sub-directories under their
+# parent's mountpoints and so parents would fail to mount later. This
+# is something we really want to avoid, so as a precaution we make sure
+# that all the datasets that we manipulate are already mounted.
+#
+unmounted_datasets = [ds for ds in datasets if ds[2] != 'yes']
+datasets = [ds for ds in datasets if ds not in unmounted_datasets]
+
+if unmounted_datasets:
+    print("WARNING: Not clearing sharenfs property for the following %d "
+          "datasets because they are unmounted:" % len(unmounted_datasets))
+    for ds in unmounted_datasets:
+        print("  %s" % ds[0])
+
+if datasets:
+    #
+    # We must use zfs inherit to clear the sharenfs property instead
+    # of setting sharenfs=off as doing the latter would set the SOURCE
+    # of the sharenfs property to "local" instead of "default". The
+    # app-stack shares timeflows by setting sharenfs on the timeflows and
+    # letting the setting propagate to its children, however this
+    # would not longer work if SOURCE for the sharenfs property is set to
+    # "local" for the children.
+    #
+    # We want to call zfs inherit on the parent datasets before the children,
+    # as such we sort the dataset names by length before traversing them.
+    #
+    datasets.sort(key=lambda ds: len(ds[0]))
+    print("Clearing sharenfs property for the following %d datasets:"
+          % len(datasets))
+    for ds in datasets:
+        print("  %s" % ds[0])
+        subprocess.check_call(["zfs", "inherit", "sharenfs", ds[0]])
+    print("Clearing sharenfs properties completed.")

--- a/files/common/var/lib/delphix-platform/os-migration
+++ b/files/common/var/lib/delphix-platform/os-migration
@@ -20,6 +20,7 @@ MIGRATE_CONFIG_LOG="/var/delphix/migration/log"
 PG_REINDEX=/var/delphix/server/db/force-reindex
 MGMT_SERVICE_OVERRIDE="/run/systemd/system/delphix-mgmt.service.d/override.conf"
 POSTGRES_SERVICE_OVERRIDE="/run/systemd/system/delphix-postgres@default.service.d/override.conf"
+CLEAR_SHARENFS="/var/lib/delphix-platform/clear-sharenfs"
 PLATFORM_TYPE=$(cat /var/lib/delphix-appliance/platform)
 
 # shellcheck disable=SC1091
@@ -137,8 +138,7 @@ function perform_migration() {
 	# failed to quiesce.
 	#
 	echo "clearing sharenfs properties"
-	zfs inherit -r sharenfs domain0 ||
-		die "failed to clear sharenfs properties"
+	"$CLEAR_SHARENFS" || die "failed to clear sharenfs properties"
 
 	#
 	# domain0/mds is owned by delphix:staff on Illumos, and on Linux


### PR DESCRIPTION
Instead of calling "zfs inherit" recursively on domain0, which tries to
clear sharenfs on every single dataset under domain0, the new approach is
to first identify which datasets have sharenfs set and then clear them one
by one. Datasets that are not mounted are ignored since clearing sharenfs
on unmounted datasets can end-up mounting them without first mounting
their parents, which will automatically create directories for their
mountpoints and later prevent the parent datasets from being mounted
due to their mount directories being not empty.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Other information

Note that I'm not opening a PR on master because we are not allowing migrations to 6.1 (Also my testing on master was failing because of DLPX-68071).

## Testing

- migration: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2811/
- environment resiliency sanity test: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/3284/
- manually tested the script with some datasets unmounted