### PR TITLE
DLPX-68392 performance regression on linux kernel 5.3 due to init_on_alloc

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -98,3 +98,18 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT elevator=noop"
 #
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=256M,high"
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=256M,low"
+
+#
+# Disable unnecessary zeroing of allocated pages.
+#
+# The 5.3 linux kernel adds a new feature which allows pages to be
+# zeroed when allocating or freeing them: init_on_alloc and
+# init_on_free. init_on_alloc is enabled by default on Ubuntu. ZFS
+# allocates and frees pages frequently (via the ABD structure), e.g. for
+# every disk access. The additional overhead of zeroing these pages is
+# significant. I measured a ~40% regression in performance of an
+# uncached "zfs send ... >/dev/null".
+#
+# Upstream commit: 6471384af2a6530696fc0203bafe4de41a23c9ef
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT init_on_alloc=0"


### PR DESCRIPTION
The 5.3 linux kernel adds a new feature which allows pages to be zeroed when allocating or freeing them: init_on_alloc and init_on_free. init_on_alloc is enabled by default on Ubuntu. ZFS allocates and frees pages frequently (via the ABD structure), e.g. for every disk access. The additional overhead of zeroing these pages is significant. I measured a ~40% regression in performance of an uncached "zfs send ... >/dev/null".
init_on_alloc enabled: http://pharos.delphix.com/shares/export/home/mahrens/FlameGraph/29956.svg
init_on_alloc disabled: http://pharos.delphix.com/shares/export/home/mahrens/FlameGraph/14672.svg
We should disable this in the product by setting init_on_alloc=0 in the GRUB kernel boot parameters.
Linux kernel commit: https://github.com/torvalds/linux/commit/6471384af2a6530696fc0203bafe4de41a23c9ef

testing: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2826/