### PR TITLE
DLPX-68188 Login timeout too aggressive for CRA workflows

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -475,6 +475,14 @@
     - variant is regex("external-.*")
 
 #
+# Increase login timeout to give support more time to interact with CRA via the console.
+#
+- lineinfile:
+    path: /etc/login.defs
+    regexp: '^LOGIN_TIMEOUT[\t ]*\d*$'
+    line: 'LOGIN_TIMEOUT    300'
+
+#
 # Configure kdump so that makedumpfile excludes ZFS ARC file data pages
 #
 - lineinfile:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: DLPX-68188
The login program used for console support logins times out after 60 seconds, which is often insufficient for support when using CRA to obtain the challenge code and enter the response code. On illumos, this timeout was 300 seconds.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Increased the timeout to 300 seconds, on par with illumos,

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2876/flowGraphTable/

Verified that the modified setting indeed results in a timeout at 300 seconds on the console, up from the 60 seconds before the fix.