### PR TITLE
DLPX-67907 Upgrade verification / apply fails if rpool/crashdump is full or larger than default

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -61,24 +61,38 @@
 
 #
 # We want the quota on the crashdump dataset to be sized accordingly
-# based on the capacity of rpool. Thus, we use this command to query the
-# rpool size, and then use this value later to set the crashdump quota.
+# based on the capacity of rpool and space already used by crashdump.
+# We pick greater of ( 50% of rpool, space used by crashdump).
+# We use the following commands to query the rpool size and used
+# crashdump space, and use these values later to set the crashdump quota.
+# We also bump up the used space by 1GB in case it is currently filling
+# up to avoid a race
+# This is done to ensure its contents can't run rpool out of space
 #
+
+- zfs:
+    name: rpool/crashdump
+    state: present
+  when: not ansible_is_chroot
+
 - command: zpool list -Hpo size rpool
   register: rpool_size_bytes
   when: not ansible_is_chroot
 
-#
-# Reconfigure the crashdump dataset. The initial configuration was performed
-# by appliance build so we only update the configuration here. In particular,
-# we want to enforce a quota to ensure its contents can't run rpool out
-# of space.
-#
+- zfs_facts:
+    name: rpool/crashdump
+    recurse: no
+    parsable: yes
+    properties: used
+    type: filesystem
+  register: crashdump
+  when: not ansible_is_chroot
+
 - zfs:
     name: rpool/crashdump
     state: present
     extra_zfs_properties:
-      quota: "{{ rpool_size_bytes.stdout|int / 2 }}"
+      quota: "{{ [rpool_size_bytes.stdout|int / 2, crashdump.ansible_facts.ansible_zfs_datasets[0].used|int + 1073741824]| max }}"
   when: not ansible_is_chroot
 
 #


### PR DESCRIPTION
Bugfix: On older engines with smaller roool sizes, support sometimes manually sets the crashdump quota to a higher number to allow system dumps to be stored. The app-gate has logic to clean the dumps. 
Currently the quota is set to 50% which can fail if crashdump is using >50%.  "msg": "cannot set property for 'rpool/crashdump': size is less than current used or reserved space\n"
This takes care of the case by taking into account both used space and size of rpool. If the dumps get cleaned up, on the next upgrade quota will be set back to 50%.

Testing: 
git ab-pre-push --test-upgrade-from 6.0.1.0: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2971/
Rerun of upgrade which failed due to a mssql bug: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/3485/

Upgrade testing: Verified on an engine which has crashdump >50% of rpool, upgrade verification fails without the fix but passes with the fix.

Followed the readme and made sure "./scripts/docker-run.sh make packages" works.