### PR TITLE
DLPX-66808 Boot/splash screen for Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,30 @@ jobs:
       - uses: actions/checkout@v2
       - run: docker build -t delphix-platform:latest docker
       - run: ./scripts/docker-run.sh make shfmtcheck
+  check-pylint:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - run: python3 -m pip install pylint
+      - run: pylint -d invalid-name files/common/usr/bin/delphix-startup-screen
+  check-yapf:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - run: python3 -m pip install yapf
+      - run: yapf --diff --style google files/common/usr/bin/delphix-startup-screen
+  check-mypy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - run: python3 -m pip install mypy
+      - run: mypy --ignore-missing-imports files/common/usr/bin/delphix-startup-screen

--- a/debian/rules
+++ b/debian/rules
@@ -56,6 +56,7 @@ DEPENDS += ansible, \
 	   openssh-server, \
 	   openssl, \
 	   policykit-1, \
+	   python3, \
 	   rng-tools, \
 	   systemd-container, \
 	   ubuntu-minimal,

--- a/files/common/etc/update-motd.d/00-delphix
+++ b/files/common/etc/update-motd.d/00-delphix
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-version=$(get-appliance-version | awk -F'+' '{print $1}')
+version=$(get-appliance-version --snapshot)
 printf "Welcome to Delphix %s\\n" "$version"

--- a/files/common/lib/systemd/system/getty@tty1.service.d/override.conf
+++ b/files/common/lib/systemd/system/getty@tty1.service.d/override.conf
@@ -1,0 +1,6 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty -t 120 -o '-p -- \\u' --noclear %I $TERM
+ExecStartPre=-/usr/bin/delphix-startup-screen
+StandardInput=tty
+StandardOutput=tty

--- a/files/common/lib/systemd/system/serial-getty@ttyS0.service.d/override.conf
+++ b/files/common/lib/systemd/system/serial-getty@ttyS0.service.d/override.conf
@@ -1,0 +1,6 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty -t 120 -o '-p -- \\u' --keep-baud 115200,38400,9600 %I $TERM
+ExecStartPre=-/usr/bin/delphix-startup-screen
+StandardInput=tty
+StandardOutput=tty

--- a/files/common/usr/bin/delphix-startup-screen
+++ b/files/common/usr/bin/delphix-startup-screen
@@ -1,0 +1,394 @@
+#!/usr/bin/python3
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+This program displays the delphix console screen which includes
+the IP address, hostname, and services (description and status).
+"""
+
+import curses
+import curses.ascii
+import curses.textpad
+import sys
+import os
+import logging
+import subprocess
+from typing import List, Any, Tuple, Generator
+
+STATUS_HEADER: str = "STATUS\t\t\tSERVICE\t\t\t"
+LAYOUT_STR: str = "Keyboard layout (press 9 to change):"
+CONSOLE_STR: str = "Press any other key for console access."
+KEY_LAYOUT_SELECT_STR: str = "Select a keyboard layout by number [1-%d]:"
+LOGO: str = "Delphix Version "
+
+log_file: str = "/tmp/dpx_startup_screen.log"
+
+website: str = "www.delphix.com"
+
+
+def get_svcs() -> List[str]:
+    """
+    Retrieve the service name and state for each service
+    that relies on 'delphix.target'. This will dynamically
+    update based on services which are WantedBy delphix.target.
+    """
+    cmd: List[str] = ['systemctl', 'show', '-p', 'Wants', 'delphix.target']
+    cp = subprocess.run(cmd,
+                        stdout=subprocess.PIPE,
+                        universal_newlines=True,
+                        check=True)
+    return cp.stdout.split("=", 1)[1].split()
+
+
+def run_svcs(options: str = None) -> Generator:
+    """
+    Run the command to retrieve the status of all the services. The options
+    argument can be used to obtain additional output from the 'systemctl'
+    command. By default we only obtain the 'ActiveState' of the services.
+    Each line is separated by a newline and an extra newline is added to
+    separate services.
+
+    For example when requesting 'ActiveState' and 'Description' the output
+    would look like this:
+    'Delphix management service\nactive\n\nDelphix Masking Service\ninactive\n'
+
+    After invoking splitlines(), we filter out any empty lines, so that we
+    end up with a List of strings:
+    ['Delphix management service', 'active',
+    'Delphix Masking Service', 'inactive']
+    """
+
+    fields: str = 'ActiveState'
+    cmd: List[str] = ['systemctl', 'show', '--value', '-p']
+    if options:
+        fields += ',' + options
+    cmd.append(fields)
+    for svc in get_svcs():
+        cmd.append(svc)
+    cp = subprocess.run(cmd,
+                        stdout=subprocess.PIPE,
+                        universal_newlines=True,
+                        check=True)
+    yield from filter(None, cp.stdout.splitlines())
+
+
+def get_keyboard_layout() -> str:
+    """
+    Return the current keyboard layout.
+    """
+    cmd: List[str] = ['localectl', 'status']
+    cp = subprocess.run(cmd,
+                        stdout=subprocess.PIPE,
+                        universal_newlines=True,
+                        check=True)
+    output: List[str] = cp.stdout.split()
+    return output[output.index("Layout:") + 1]
+
+
+def set_keyboard_layout(layout: str) -> subprocess.CompletedProcess:
+    """
+    Set the keyboard layout based on the user selection.
+    """
+    cmd: List[str] = ['localectl', 'set-x11-keymap', layout, 'pc105']
+    subprocess.run(cmd, shell=False, check=True)
+    return subprocess.run('setupcon', shell=False, check=True)
+
+
+def get_valid_keyboard_layouts() -> List[str]:
+    """
+    Return valid keyboard layouts supported by the system.
+    """
+    cmd: List[str] = ['localectl', '--no-pager', 'list-x11-keymap-layouts']
+    cp = subprocess.run(cmd,
+                        stdout=subprocess.PIPE,
+                        universal_newlines=True,
+                        check=True)
+    return cp.stdout.splitlines()
+
+
+def load_header(stdscr) -> Any:
+    """
+    Display the header information for the main screen.
+    """
+    WIN_LEN, WIN_HT = set_common_variables(stdscr)
+    cmd = ['get-appliance-version', '--patch']
+    cp = subprocess.run(cmd,
+                        stdout=subprocess.PIPE,
+                        universal_newlines=True,
+                        check=True)
+    version: str = cp.stdout
+
+    stdscr.clear()
+    stdscr.addstr(1, 2, LOGO + str(version), curses.A_BOLD)
+    stdscr.addstr(1, WIN_LEN - len(website) - 2, website, curses.A_BOLD)
+
+    win = stdscr.subwin(WIN_HT - 4, WIN_LEN - 4, 3, 2)
+    win.bkgd(' ', curses.color_pair(2))
+    win.box()
+    return win
+
+
+def is_server_down() -> bool:
+    """
+    Determine if the server is down by looking at the state of all the
+    services. If any service is 'failed' then we declare the server down.
+    """
+    for i in run_svcs():
+        if i.strip() == "failed":
+            return True
+    return False
+
+
+def is_server_up() -> bool:
+    """
+    Determine if all the services are 'active' or 'inactive'. Inactive
+    is considered up since the service may not be enabled.
+    """
+    for i in run_svcs():
+        if i.strip() not in ("active", "inactive"):
+            return False
+    return True
+
+
+#
+# Sets the common variables.
+#
+def set_common_variables(stdscr) -> Tuple[int, int]:
+    """
+    Initialize curses colors and settings.
+    """
+    if curses.has_colors():
+        curses.start_color()
+        curses.init_pair(1, curses.COLOR_BLACK, curses.COLOR_WHITE)
+        curses.init_pair(2, curses.COLOR_WHITE, curses.COLOR_BLUE)
+        curses.init_pair(3, curses.COLOR_BLACK, curses.COLOR_GREEN)
+        curses.init_pair(4, curses.COLOR_BLACK, curses.COLOR_YELLOW)
+        curses.init_pair(5, curses.COLOR_BLACK, curses.COLOR_RED)
+        stdscr.bkgd(' ', curses.color_pair(1))
+
+    (Y, X) = stdscr.getmaxyx()
+
+    return X, Y
+
+
+def getstatus_pair(lst) -> Generator:
+    """
+    Process the status and return a list which is comprised of
+    ['service description', 'service status'].
+    """
+    for i in range(0, len(lst), 2):
+        yield lst[i:i + 2]
+
+
+def getstatus() -> str:
+    """
+    Each service returns 2 lines -- one with the description and the
+    next line with the state.
+    """
+    status = ""
+    for i in getstatus_pair(list(run_svcs("Description"))):
+        #
+        # Switch the state and description
+        #
+        status += f"{i[-1]}\t{i[0]}\n"
+    return status
+
+
+def get_network_status() -> Tuple[str, str]:
+    """
+    Returns a tuple of (hostname, ipaddr) for the main interface.
+    """
+
+    #
+    # We get the primary address based on the default route. The
+    # address we use follows the 'src' key in the output.
+    #
+    cmd = ['ip', 'route', 'show', '0.0.0.0/0']
+    cp = subprocess.run(cmd,
+                        stdout=subprocess.PIPE,
+                        universal_newlines=True,
+                        check=True)
+    output = cp.stdout.split()
+    ipaddr = output[output.index("src") + 1]
+    hostname = os.uname()[1]
+    return (hostname, ipaddr)
+
+
+# pylint: disable-msg=too-many-locals
+def display_status(stdscr, win):
+    """
+    Main display and input function. This function will display
+    the services and their status. Accepts input for keyboard layout
+    screen or to display the login prompt.
+    """
+    (Y, X) = win.getmaxyx()
+
+    layout = get_keyboard_layout()
+
+    width = X - 10
+    height = Y - 8
+    status = 0
+
+    x = int((X - width) / 2) + 2
+    y = (Y - height - 1)
+
+    win.clear()
+    win.box()
+    win.addstr(1, 2, LAYOUT_STR, curses.A_BOLD)
+    win.addstr(1, 3 + len(LAYOUT_STR), layout)
+    win.addstr(2, 2, CONSOLE_STR, curses.A_BOLD)
+
+    win.refresh()
+    stdscr.refresh()
+
+    netwin = win.subwin(2, width, Y, 5)
+    statuswin = win.subwin(height, width, y, x)
+
+    while True:
+        status += 1
+
+        if is_server_up():
+            statuswin.bkgd(' ', curses.color_pair(3))
+        elif is_server_down():
+            statuswin.bkgd(' ', curses.color_pair(5))
+        else:
+            statuswin.bkgd(' ', curses.color_pair(4))
+
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        (hostname, ipaddr) = get_network_status()
+        netwin.clear()
+        netwin.addstr(0, 0, "Host: http://" + hostname + "/", curses.A_BOLD)
+        netwin.addstr(1, 0, "IP: " + ipaddr, curses.A_BOLD)
+        netwin.noutrefresh()
+
+        # We get status every 10 secs
+        strout = getstatus()
+
+        if (status % 10) == 0:
+            status = 0
+            statuswin.clear()
+        statuswin.box()
+
+        START = 2
+        statuswin.addstr(START, 5, STATUS_HEADER, curses.A_STANDOUT)
+        START += 1
+        statuswin.hline(START, 5, curses.ACS_HLINE, 45)
+        for i in strout.split("\n"):
+            START += 1
+            statuswin.addstr(START, 2, " " * (width - 3), curses.A_BOLD)
+            statuswin.addstr(START, 5, str(i), curses.A_STANDOUT)
+        statuswin.noutrefresh()
+
+        curses.doupdate()
+
+        # Read any user keystroke if present. We wait for any keystroke
+        # for 10 secs here
+        curses.halfdelay(100)
+        keypress = stdscr.getch()
+        # -1 means timeout, anything else is a key press
+        if -1 != keypress:
+            return keypress
+
+
+def display_keyboard_layout_selection(stdscr, win):
+    """
+    This function will display a list of possible keyboard layouts
+    and allow the user to select the appropriate layout.
+    """
+    (Y, _) = win.getmaxyx()
+
+    win.clear()
+    win.box()
+
+    layouts = get_valid_keyboard_layouts()
+
+    x = 2
+    y = 1
+    width = -1
+    for (i, layout) in enumerate(layouts):
+        layoutstr = f"{i+1:>2} {layout}"
+        win.addstr(y, x, layoutstr)
+        y += 1
+        width = max(width, len(layoutstr))
+        if y >= Y - 2:
+            y = 1
+            x += width + 1
+
+    select_str = KEY_LAYOUT_SELECT_STR % len(layouts)
+    win.addstr(Y - 2, 2, select_str, curses.A_BOLD)
+    inputwin = win.subwin(1, 3, Y + 1, 5 + len(select_str))
+    inputbox = curses.textpad.Textbox(inputwin)
+
+    win.refresh()
+    stdscr.refresh()
+
+    #
+    # This validation function is passed to inputbox.edit() to validate
+    # individual keystrokes as the user types them. We want to limit the
+    # characters the user can type. For invalid characters we return
+    # Ctrl+l (refresh screen) instead of the invalid character.
+    #
+    def validate(ch):
+        # Allow any non-visual characters (e.g. backspace)
+        if not curses.ascii.isgraph(ch):
+            return ch
+        # Only allow digits (0-9)
+        if not curses.ascii.isdigit(ch):
+            return curses.ascii.ctrl('l')
+        # Do not allow digits that cause the input to be invalid
+        val = int(inputbox.gather().strip() + chr(ch))
+        if val <= 0 or val > len(layouts):
+            return curses.ascii.ctrl('l')
+        return ch
+
+    while True:
+        res = inputbox.edit(validate)
+        # If no input was given return without doing anything
+        if len(res.strip()) == 0:
+            break
+        try:
+            num = int(res)
+            if 0 < num <= len(layouts):
+                set_keyboard_layout(layouts[num - 1])
+                break
+        except ValueError:
+            pass
+
+
+#
+# Main function.
+#
+def installer_main(stdscr):
+    """
+    Main
+    """
+    stdscr.clear()
+    win = load_header(stdscr)
+
+    while True:
+        keypress = display_status(stdscr, win)
+        if keypress == ord('9'):
+            display_keyboard_layout_selection(stdscr, win)
+        else:
+            break
+
+
+if __name__ == '__main__':
+    logging.basicConfig(filename=log_file, level=logging.DEBUG)
+
+    curses.wrapper(installer_main)

--- a/files/common/usr/bin/get-appliance-version
+++ b/files/common/usr/bin/get-appliance-version
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2019 Delphix
+# Copyright 2019, 2020 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,66 @@
 set -o errexit
 set -o pipefail
 
-zfs get -Hpo value \
+function usage() {
+	echo "Usage: $(basename "$0") [-hMmps]"
+	echo
+	echo "Display the version information for the appliance. By default,"
+	echo "the full version (major, minor, patch portions, and jenkins "
+	echo "information, if it exists) are displayed."
+	echo "The following arguments may be used to refine the version"
+	echo "information:"
+	echo "-h, --help -- displays usage"
+	echo "-M, --major -- displays the major version"
+	echo "-m, --minor -- displays the major and minor version"
+	echo "-p, --patch -- displays the major, minor, and patch version"
+	echo "-s, --snapshot -- displays the major, minor, patch, and " \
+		"snapshot information"
+	exit 2
+}
+
+options=$(getopt -l "help,major,minor,patch,snapshot" -o "hMmps" -- "$@")
+eval set -- "$options"
+
+output=$(zfs get -Hpo value \
 	"com.delphix:current-version" \
-	"$(dirname "$(zfs list -Hpo name /)")" | tr -d '\n'
+	"$(dirname "$(zfs list -Hpo name /)")")
+
+if [[ $# -gt 2 ]]; then
+	echo "Error: Only one option may be selected"
+	usage
+fi
+
+if [[ $# -eq 1 ]]; then
+	echo "$output" | tr -d '\n'
+	shift
+fi
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-h | --help)
+		usage
+		break
+		;;
+	-M | --major)
+		echo "$output" | cut -d'.' -f1,2 | tr -d '\n'
+		break
+		;;
+	-m | --minor)
+		echo "$output" | cut -d'.' -f1-3 | tr -d '\n'
+		break
+		;;
+	-p | --patch)
+		echo "$output" | cut -d'-' -f1 | cut -d'.' -f1-4 | tr -d '\n'
+		break
+		;;
+	-s | --snapshot)
+		echo "$output" | cut -d'+' -f1 | tr -d '\n'
+		break
+		;;
+	--)
+		shift
+		break
+		;;
+	esac
+done
+exit 0

--- a/files/common/usr/bin/get-property-from-image
+++ b/files/common/usr/bin/get-property-from-image
@@ -80,7 +80,7 @@ UNPACK_DIR=$(mktemp -d -p "$UPDATE_DIR" -t unpack.XXXXXXX)
 [[ -d "$UNPACK_DIR" ]] || die "failed to create unpack directory '$UNPACK_DIR'"
 pushd "$UNPACK_DIR" &>/dev/null || die "'pushd $UNPACK_DIR' failed"
 
-DELPHIX_SIGNATURE_VERSION=$(/usr/bin/get-appliance-version | cut -d - -f 1 | cut -d . -f 1-2)
+DELPHIX_SIGNATURE_VERSION=$(/usr/bin/get-appliance-version --major)
 
 tar -x SHA256SUMS SHA256SUMS.sig."$DELPHIX_SIGNATURE_VERSION" version.info -f "$UPGRADE_IMAGE_PATH" ||
 	die 14 "failed to extract files from upgrade image '$UPGRADE_IMAGE_PATH'"

--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -110,7 +110,7 @@ for file in SHA256SUMS prepare; do
 	[[ -f "$file" ]] || die 15 "image is corrupt; missing '$file' file"
 done
 
-DELPHIX_SIGNATURE_VERSION=$(/usr/bin/get-appliance-version | cut -d - -f 1 | cut -d . -f 1-2)
+DELPHIX_SIGNATURE_VERSION=$(/usr/bin/get-appliance-version --major)
 
 if [[ -z "$opt_s" ]]; then
 	openssl dgst -sha256 \


### PR DESCRIPTION
This PR add the `delphix-startup-screen` as a python3 program and converts the keyboard logic to use `localectl`. The delphix console is started on both `ttyS0` and `tty1` and it runs as a pre-exec script in the `serial-getty@` and `getty@` services. We override only the `getty@tty1.service` (I think linux can have up to 6 ttys).