### PR TITLE
Crash Kernel should reboot after 10 seconds once it panics

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -455,12 +455,54 @@
     line: 'LOGIN_TIMEOUT    300'
 
 #
-# Configure kdump so that makedumpfile excludes ZFS ARC file data pages
+# MAKEDUMP_ARGS - Configure makedumpfile to:
+#       [1] Compress the dump (-c)
+#       [2] Filter out pages that are zero, in the page or private cache,
+#           part of user data, or marked as freed (-d 31)
+#       [3] Print common, error, and report messages (--message-level 22)
+#       [4] Exclude ZFS ARC file data pages
+#           (--private-page-filter 0x2F5ABDF11ECAC4E)
+#       * see man page makedumpfile(8) for more info
+#
+# KDUMP_CMDLINE_APPEND - We first append the default parameters passed
+#       by the kdump-tools package:
+#       [1] Force drivers to reset the underlying device during
+#           initialization (reset_devices)
+#       [2] Run the kdump-tools-dump service that will invoke
+#           makedumpfile (systemd.unit=kdump-tools-dump.service)
+#       [3] We don't intend to use multithreaded programs in the
+#           crash kernel, so in order to save some memory we specify
+#           the number of CPUs to be 1 (nr_cpus=1)
+#       [4] Reduce driver initialization failures due to shared
+#           interrupts in the crash kernel by searching all
+#           handlers when an interrupt is not handled (irqpoll)
+#       [5] Disable the USB subsystem as we won't be needing it
+#           (nousb)
+#       [6] Allow the standard Linux storage driver to function
+#           when running on Hyper-V, otherwise kexec'ing a new
+#           kernel doesn't work (ata_piix.prefer_ms_hyperv=0)
+#           See the following link for more info:
+#           https://support.microsoft.com/ca-es/help/2858695
+#
+#       Then we go ahead and append our own options on top of the
+#       defaults:
+#       [1] If the crash-kernel panics too we don't want to be
+#           stuck there forever. Ensure we reboot when that
+#           happens after 10 seconds (panic=10)
+#
+#       * all of the above can be found in
+#         Documentation/admin-guide/kernel-parameters.txt and
+#         Documentation/kdump/kdump.txt of the Linux Kernel repo.
 #
 - lineinfile:
     path: /etc/default/kdump-tools
-    regexp: '^#?MAKEDUMP_ARGS='
-    line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"'
+    regexp: "{{ item.regex }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regex: '^#?MAKEDUMP_ARGS='
+      line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"'
+    - regex: '^#?KDUMP_CMDLINE_APPEND='
+      line: 'KDUMP_CMDLINE_APPEND="reset_devices systemd.unit=kdump-tools-dump.service nr_cpus=1 irqpoll nousb ata_piix.prefer_ms_hyperv=0 panic=10"'
 
 #
 # Disable all motd scripts except for those provided by Delphix by removing


### PR DESCRIPTION
### Testing

ab-pre-push: (unrelated failure in dx-test,linux-tests)
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3111/

Testing on a VM from that pre-push:
```
# ---------------------------------------------------------------------------
# Makedumpfile options:
# MAKEDUMP_ARGS - extra arguments passed to makedumpfile (8).  The default,
#     if unset, is to pass '-c -d 31' telling makedumpfile to use compression
#     and reduce the corefile to in-use kernel pages only.
MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"


# ---------------------------------------------------------------------------
# Kexec/Kdump args
# KDUMP_KEXEC_ARGS - Additional arguments to the kexec command used to load
#     the kdump kernel
#     Example - Use this option on x86 systems with PAE and more than
#     4 gig of memory:
#         KDUMP_KEXEC_ARGS="--elf64-core-headers"
# KDUMP_CMDLINE - The default is to use the contents of /proc/cmdline.
#     Set this variable to override /proc/cmdline.
# KDUMP_CMDLINE_APPEND - Additional arguments to append to the command line
#     for the kdump kernel.  If unset, it defaults to
#     "reset_devices systemd.unit=kdump-tools-dump.service nr_cpus=1 irqpoll nousb ata_piix.prefer_ms_hyperv=0"
#KDUMP_KEXEC_ARGS=""
#KDUMP_CMDLINE=""
KDUMP_CMDLINE_APPEND="reset_devices systemd.unit=kdump-tools-dump.service nr_cpus=1 irqpoll nousb ata_piix.prefer_ms_hyperv=0 panic=10"```
```

Again on VMware while looking at the console on a VM that I expected it would run out of memory while loading the crash kernel:
```
[    2.485118]  __page_cache_alloc+0x6a/0xa0
[    2.485118]  pagecache_get_page+0x9c/0x2b0
:set nonu                                                                                                            1,1           Top
[    2.485118]  generic_perform_write+0xb3/0x1b0
[    2.485118]  __generic_file_write_iter+0x1aa/0x1d0
[    2.485118]  generic_file_write_iter+0xbd/0x160
[    2.485118]  new_sync_write+0x125/0x1c0
[    2.485118]  __vfs_write+0x29/0x40
[    2.485118]  vfs_write+0xb1/0x1a0
[    2.485118]  ? md_run_setup+0xc3/0xc3
[    2.485118]  ksys_write+0xa7/0xe0
[    2.485118]  xwrite+0x2e/0x61
[    2.485118]  do_copy+0x9f/0xcd
[    2.485118]  write_buffer+0x2b/0x3c
[    2.485118]  flush_buffer+0x39/0x91
[    2.485118]  __gunzip+0x277/0x31b
[    2.485118]  ? bunzip2+0x3c1/0x3c1
[    2.485118]  ? write_buffer+0x3c/0x3c
[    2.485118]  ? md_run_setup+0xc3/0xc3
[    2.485118]  ? __gunzip+0x31b/0x31b
[    2.485118]  gunzip+0x11/0x13
[    2.485118]  ? md_run_setup+0xc3/0xc3
[    2.485118]  unpack_to_rootfs+0x187/0x2c0
[    2.485118]  ? md_run_setup+0xc3/0xc3
[    2.485118]  ? do_name+0x2b8/0x2b8
[    2.485118]  ? set_debug_rodata+0x17/0x17
[    2.485118]  populate_rootfs+0x5d/0x10b
[    2.485118]  do_one_initcall+0x4a/0x1fa
[    2.485118]  kernel_init_freeable+0x1c6/0x26d
[    2.485118]  ? rest_init+0xb0/0xb0
[    2.485118]  kernel_init+0xe/0x110
[    2.485118]  ret_from_fork+0x1f/0x40
[    2.485118] Rebooting in 10 seconds. // <------
...
... actually rebooted ...
...
```

Then added more memory to the crash kernel and forced a panic again to make sure that we can still get crash dumps like before.