### PR TITLE
Add scripts and package for use in creating Nitro dev links (master)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -104,7 +104,7 @@ DEPENDS += pam-challenge-response, \
 	   pam-challenge-response-dbgsym,
 
 # Platform-specific dependencies
-DEPENDS.aws =
+DEPENDS.aws = nvme-cli,
 DEPENDS.azure = walinuxagent, linux-cloud-tools-azure,
 DEPENDS.esx = open-vm-tools,
 DEPENDS.gcp = gce-compute-image-packages, python-google-compute-engine, \

--- a/files/common/etc/udev/rules.d/999-aws-ebs-nvme.rules
+++ b/files/common/etc/udev/rules.d/999-aws-ebs-nvme.rules
@@ -1,0 +1,18 @@
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+SUBSYSTEM=="block", KERNEL=="nvme*[0-9]n[0-9]", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/bin/ebs-nvme-mapping /dev/%k" SYMLINK+="%c"
+SUBSYSTEM=="block", KERNEL=="nvme*[0-9]n*[0-9]p*[0-9]", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/bin/ebs-nvme-mapping /dev/%k" SYMLINK+="%c%n"

--- a/files/common/usr/bin/ebs-nvme-mapping
+++ b/files/common/usr/bin/ebs-nvme-mapping
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# MIT License
+#
+# This script is based on https://github.com/oogali/ebs-automatic-nvme-mapping,
+# with some modifications by Delphix
+#
+# Copyright (c) 2018 Omachonu Ogali
+# Copyright (c) 2020 Delphix
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# To be used with the udev rule: /etc/udev/rules.d/999-aws-ebs-nvme.rules
+
+if [[ ! -x "$(command -v nvme)" ]]; then
+	echo "ERROR: NVME tools not installed." >>/dev/stderr
+	exit 1
+fi
+
+if [[ ! -b ${1} ]]; then
+	echo "ERROR: cannot find block device ${1}" >>/dev/stderr
+	exit 1
+fi
+
+# capture 32 bytes at an offset of 3072 bytes from the raw-binary data
+# not all block devices are extracted with /dev/ prefix
+# use `xvd` prefix instead of `sd`
+# remove all trailing spaces
+nvme_link=$(
+	nvme id-ctrl --raw-binary "${1}" |
+		cut -c3073-3104 |
+		sed 's/^\/dev\///g' |
+		sed 's/sd/xvd/g' |
+		tr -d '[:space:]'
+)
+echo "$nvme_link"


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
Currently, Delphix Engines on AWS Nitro instances use `/dev/nvmeN` type links for creating pools. This causes problems if we ever need to change between Nitro and non-Nitro instance types - i.e. `domain0` doesn't import.  


Issue Number: https://jira.delphix.com/browse/DLPX-68810

## What is the new behavior?

Out strategy is to use the `nvme-cli` package to translate between the nvme-type name to the underlying EBS identifier (`/dev/xvdN`). A new udev rule will invoke this script and create the new links. Then, all AWS DEs will use those links and we don't need to handle the special case in the app-stack. 

This PR introduces the new package, the script and the new udev rule. Other PRs will be needed to change pool creation in the app-stack and pool import during migration. 

I'm looking for feedback about whether or not these are the right places to add the scripts and package dependencies. 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Testing
Manually tested that this change plus http://reviews.delphix.com/r/57228/ cause the DE to use the `/dev/xvdN` links for pool create and device management. Changing instance types from T3 to T2 and back to T3 worked fine: `domain0` was properly imported in all cases and storage operations like removal and expansion worked fine. 

ab-pre-push (black box failures, seemingly related to github outage): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3183/flowGraphTable/

another ab-pre-push (passed, except `precheckin` hit infra issues): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3187/flowGraphTable/
re-running `precheckin`: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-self-service/30440/console
