### PR TITLE
Add nvme-cli, udev rule and script to create nitro ebs dev links (6.0.2.0 backport)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -98,7 +98,7 @@ DEPENDS += pam-challenge-response, \
 	   pam-challenge-response-dbgsym,
 
 # Platform-specific dependencies
-DEPENDS.aws =
+DEPENDS.aws = nvme-cli,
 DEPENDS.azure = walinuxagent, linux-cloud-tools-azure,
 DEPENDS.esx = open-vm-tools,
 DEPENDS.gcp = gce-compute-image-packages, python-google-compute-engine, \

--- a/files/common/etc/udev/rules.d/999-aws-ebs-nvme.rules
+++ b/files/common/etc/udev/rules.d/999-aws-ebs-nvme.rules
@@ -1,0 +1,18 @@
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+SUBSYSTEM=="block", KERNEL=="nvme*[0-9]n[0-9]", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/bin/ebs-nvme-mapping /dev/%k" SYMLINK+="%c"
+SUBSYSTEM=="block", KERNEL=="nvme*[0-9]n*[0-9]p*[0-9]", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/bin/ebs-nvme-mapping /dev/%k" SYMLINK+="%c%n"

--- a/files/common/usr/bin/ebs-nvme-mapping
+++ b/files/common/usr/bin/ebs-nvme-mapping
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# MIT License
+#
+# This script is based on https://github.com/oogali/ebs-automatic-nvme-mapping,
+# with some modifications by Delphix
+#
+# Copyright (c) 2018 Omachonu Ogali
+# Copyright (c) 2020 Delphix
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# To be used with the udev rule: /etc/udev/rules.d/999-aws-ebs-nvme.rules
+
+if [[ ! -x "$(command -v nvme)" ]]; then
+	echo "ERROR: NVME tools not installed." >>/dev/stderr
+	exit 1
+fi
+
+if [[ ! -b ${1} ]]; then
+	echo "ERROR: cannot find block device ${1}" >>/dev/stderr
+	exit 1
+fi
+
+# capture 32 bytes at an offset of 3072 bytes from the raw-binary data
+# not all block devices are extracted with /dev/ prefix
+# use `xvd` prefix instead of `sd`
+# remove all trailing spaces
+nvme_link=$(
+	nvme id-ctrl --raw-binary "${1}" |
+		cut -c3073-3104 |
+		sed 's/^\/dev\///g' |
+		sed 's/sd/xvd/g' |
+		tr -d '[:space:]'
+)
+echo "$nvme_link"


### PR DESCRIPTION
### Overview
This is a backport of https://github.com/delphix/delphix-platform/pull/214 to support AWS instances to change to and from Nitro. 

Note that since there is not Nitro support for Illumos DEs, Nitro instances will not be under going migration. I am planning on testing that a migrated engine on 6.0.2.0 can be safely changed to Nitro. 

### Testing
ab-pre-push (passed):  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3199/

Manually tested device operations as well as changing instance type for migrated engine. 