### PR TITLE
DLPX-69192 Current upgrade image tarfile names are not supported by unpack-image

### DIFF
--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -86,8 +86,8 @@ shift $((OPTIND - 1))
 IMAGE="$1"
 
 case "$IMAGE" in
-*.upgrade.tar) ;;
-*) die 12 "The upgrade image must be a '.upgrade.tar' file" ;;
+*.tar) ;;
+*) die 12 "The upgrade image must be a '.tar' file" ;;
 esac
 
 UPGRADE_IMAGE_PATH="$(readlink -f "$IMAGE")"


### PR DESCRIPTION
[DLPX-69192](https://jira.delphix.com/browse/DLPX-69192)
[ab-pre-push](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3288/)

Currently the UI handles converting uploaded images from `.tar` to `.upgrade.tar`
```
UI behavior:
the UI uses UpgradeUploadExecutorImpl.java which changes the file name
/**

Returns a randomly generated filename for the given file while preserving its extension.
Assumes (asserts) that the input filename ends in .tar or .tar.gz.
@param inputFilename
@return A randomly generated filename for an upgrade image.
*/
@VisibleForTesting
public static String generateFilename(String inputFilename, boolean random)
Unknown macro: { boolean endsWithTarGz = inputFilename.endsWith(".tar.gz"); checkState(endsWithTarGz || inputFilename.endsWith(".tar")); String fileExtension = endsWithTarGz ? "tar.gz" }
From debug log:
[2020-03-30 12:04:48,165][INFO][upg.impl.UpgradeUploadExecutorImpl#writeToDisk:312][http-nio-127.0.0.1-8586-exec-10][] Creating file "c684c16f6bd89f64015bdc0f32d72780.upgrade.tar" from uploaded file named "Delphix_6.0.1.0_2020-03-17-00-39_Standard_Upgrade.tar"
For the QA-gate, we use the internal builds even for releases that are already out:
s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/appliance-build/6.0/release/post-push/235/upgrade-artifacts/internal-dev.upgrade.tar
Looks like this error only happens if we use the shell script for the upgrade tar from the download site.
```

However, if we run the unpack script on an upgrade tar from the download site, then we will run into errors since it's in the form `Delphix_6.0.1.0_2020-03-17-00-39_Standard_Upgrade.tar` for example.

We can either change how the upgrade tars on the download site are named, or we can change how we check the image extensions. Since the UI changes the extension to `.upgrade.tar`, there's minimal risk of getting a badly named image. 

Open to other approaches if this isn't the preferable way to handle this.