### PR TITLE
DLPX-69500 [Backport of DLPX-69192 to 6.0.3.0] Current upgrade image tarfile names are not supported by unpack-image

### DIFF
--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -86,8 +86,8 @@ shift $((OPTIND - 1))
 IMAGE="$1"
 
 case "$IMAGE" in
-*.upgrade.tar) ;;
-*) die 12 "The upgrade image must be a '.upgrade.tar' file" ;;
+*.tar) ;;
+*) die 12 "The upgrade image must be a '.tar' file" ;;
 esac
 
 UPGRADE_IMAGE_PATH="$(readlink -f "$IMAGE")"


### PR DESCRIPTION
[JIRA](https://jira.delphix.com/browse/DLPX-69500)
[ab-pre-push](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3300/)
PR from master: #218 