### PR TITLE
DLPX-69870 Upgrade verification fails on GCP because google-instance-setup.service hangs inside container

### DIFF
--- a/files/common/lib/systemd/system/google-instance-setup.service.d/override.conf
+++ b/files/common/lib/systemd/system/google-instance-setup.service.d/override.conf
@@ -1,0 +1,11 @@
+#
+# During upgrade verification, the root filesystem will be booted as a
+# container using systemd-nspawn. Engines running on GCP have the
+# google-instance-setup service enabled by default. When this service
+# runs in a container, it fails to activate and cause the start container
+# operation to hang, leading to upgrade verification hanging.
+# Thus, to workaround this problem, we explicitly disable this service
+# from running when inside of the container.
+#
+[Unit]
+ConditionVirtualization=!container


### PR DESCRIPTION
google-instance-setup.service hangs within a systemd-nspawn container. This service is unnecessary for the upgrade container. Solution is to add an override parameter that adds a "!container" condition to the service execution.

SUBMITTED git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3526/