### PR TITLE
DLPX-70303 Enable some debug statements in the iSCSI driver

### DIFF
--- a/files/common/lib/systemd/system/delphix-platform.service
+++ b/files/common/lib/systemd/system/delphix-platform.service
@@ -23,6 +23,7 @@ Before=rsync.service
 [Service]
 Type=oneshot
 ExecStart=/var/lib/delphix-platform/ansible/apply
+ExecStart=/var/lib/delphix-platform/dynamic-debug
 RemainAfterExit=yes
 
 #

--- a/files/common/var/lib/delphix-platform/dynamic-debug
+++ b/files/common/var/lib/delphix-platform/dynamic-debug
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Enable specific pr_debug() statements in the kernel to aid in debugging
+# potential issues. The debug statements can only be enabled on loaded modules,
+# so we manually load some modules that aren't loaded by default.
+#
+modprobe target_core_mod
+modprobe iscsi_target_mod
+cat <<-EOF >/sys/kernel/debug/dynamic_debug/control
+	# iSCSI debug info related to LUN RESETs and iSCSI reconnects.
+	file target_core_tmr.c +p
+	func iscsit_release_commands_from_conn +p
+EOF
+
+echo "pr_debug statements enabled:"
+grep '=p' /sys/kernel/debug/dynamic_debug/control
+
+#
+# We do not want to fail the service if some of the dynamic debug fails
+# to apply
+#
+exit 0


### PR DESCRIPTION
This change enables the following debug statements:
```
/home/ubuntu/6030/aws/linux/drivers/target/target_core_tmr.c:390 [target_core_mod]core_tmr_lun_reset =p "LUN_RESET: %s for [%s] Complete\012"
/home/ubuntu/6030/aws/linux/drivers/target/target_core_tmr.c:383 [target_core_mod]core_tmr_lun_reset =p "LUN_RESET: SCSI-2 Released reservati
/home/ubuntu/6030/aws/linux/drivers/target/target_core_tmr.c:367 [target_core_mod]core_tmr_lun_reset =p "LUN_RESET: %s starting for [%s], tas
/home/ubuntu/6030/aws/linux/drivers/target/target_core_tmr.c:362 [target_core_mod]core_tmr_lun_reset =p "LUN_RESET: TMR caller fabric: %s ini
/home/ubuntu/6030/aws/linux/drivers/target/target_core_tmr.c:322 [target_core_mod]core_tmr_drain_state_list =p "LUN_RESET: ITT[0x%08llx] - %s
/home/ubuntu/6030/aws/linux/drivers/target/target_core_tmr.c:226 [target_core_mod]core_tmr_drain_tmr_list =p "LUN_RESET: %s releasing TMR %p
/home/ubuntu/6030/aws/linux/drivers/target/target_core_tmr.c:100 [target_core_mod]__target_check_io_state =p "Attempted to abort io tag: %llu
/home/ubuntu/6030/aws/linux/drivers/target/iscsi/iscsi_target.c:4101 [iscsi_target_mod]iscsit_release_commands_from_conn =p "%s: TMR freed"
/home/ubuntu/6030/aws/linux/drivers/target/iscsi/iscsi_target.c:4099 [iscsi_target_mod]iscsit_release_commands_from_conn =p "%s: freeing TMR
```
Those statements will be important to have to track LUN RESETs as they happen on customer systems. If there are any remaining issues with LUN RESETS, this would help debug any potential issues.

Note that this could generate a moderate amount of extra debug info in kern.log on systems that undergo frequent LUN resets.

## Additional info
This list could be expanded in the future, allowing us to add more debug statements.

## Testing
- Manually confirmed that the desired debug statements were enabled on a 6.0/stage system.
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3605/