### PR TITLE
DLPX-70304 [Backport of DLPX-70303 to 6.0.3.0] Enable some debug statements in the iSCSI driver

### DIFF
--- a/files/common/lib/systemd/system/delphix-platform.service
+++ b/files/common/lib/systemd/system/delphix-platform.service
@@ -23,6 +23,7 @@ Before=rsync.service
 [Service]
 Type=oneshot
 ExecStart=/var/lib/delphix-platform/ansible/apply
+ExecStart=/var/lib/delphix-platform/dynamic-debug
 RemainAfterExit=yes
 
 #

--- a/files/common/var/lib/delphix-platform/dynamic-debug
+++ b/files/common/var/lib/delphix-platform/dynamic-debug
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Enable specific pr_debug() statements in the kernel to aid in debugging
+# potential issues. The debug statements can only be enabled on loaded modules,
+# so we manually load some modules that aren't loaded by default.
+#
+modprobe target_core_mod
+modprobe iscsi_target_mod
+cat <<-EOF >/sys/kernel/debug/dynamic_debug/control
+	# iSCSI debug info related to LUN RESETs and iSCSI reconnects.
+	file target_core_tmr.c +p
+	func iscsit_release_commands_from_conn +p
+EOF
+
+echo "pr_debug statements enabled:"
+grep '=p' /sys/kernel/debug/dynamic_debug/control
+
+#
+# We do not want to fail the service if some of the dynamic debug fails
+# to apply
+#
+exit 0


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/delphix-platform/pull/228.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3623/