### PR TITLE
DLPX-70614 [Backport of DLPX-70512 to 6.0.3.0] Long zio delays likely caused by Linux IO scheduler write throttling logic

### DIFF
--- a/files/common/lib/udev/rules.d/60-dlpx-schedulers.rules
+++ b/files/common/lib/udev/rules.d/60-dlpx-schedulers.rules
@@ -1,0 +1,6 @@
+#
+# Delphix: this setting disables the write throttle algorithm that is used in
+# the Linux IO scheduler for all block devices as we've seen problems with it.
+# We explicitly disable it for zvols as it doesn't seem to apply to them anyway.
+#
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="zd*", ATTR{queue/wbt_lat_usec}="0"


### PR DESCRIPTION
Disable Linux IO scheduler write throttle logic for all disks.

## Testing
- Manually verified on a system that the tunable was applied and that write throttle was effectively disabled (wb_normal = 0):
```
$ for lat in /sys/block/sd*/queue/wbt_lat_usec; do echo "$lat: $(cat $lat)"; done
/sys/block/sda/queue/wbt_lat_usec: 0
/sys/block/sdb/queue/wbt_lat_usec: 0
/sys/block/sdc/queue/wbt_lat_usec: 0
/sys/block/sdd/queue/wbt_lat_usec: 0

$ sudo bash -c 'for norm in /sys/kernel/debug/block/sd*/rqos/wbt/wb_normal; do echo "$norm: $(cat $norm)"; done'
/sys/kernel/debug/block/sda/rqos/wbt/wb_normal: 0
/sys/kernel/debug/block/sdb/rqos/wbt/wb_normal: 0
/sys/kernel/debug/block/sdc/rqos/wbt/wb_normal: 0
/sys/kernel/debug/block/sdd/rqos/wbt/wb_normal: 0
```
- ab-pre-push (esx): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3691/
- ab-pre-push (aws): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3692/