### PR TITLE
DLPX-70512 Long zio delays likely caused by Linux IO scheduler write throttling logic

### DIFF
--- a/files/common/lib/udev/rules.d/60-dlpx-schedulers.rules
+++ b/files/common/lib/udev/rules.d/60-dlpx-schedulers.rules
@@ -1,0 +1,6 @@
+#
+# Delphix: this setting disables the write throttle algorithm that is used in
+# the Linux IO scheduler for all block devices as we've seen problems with it.
+# We explicitly disable it for zvols as it doesn't seem to apply to them anyway.
+#
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="zd*", ATTR{queue/wbt_lat_usec}="0"


### PR DESCRIPTION
This is a clean cherry-pick of https://github.com/delphix/delphix-platform/pull/232

## Testing
- ab-pre-push (esx): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3698/
- ab-pre-push (aws): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3699/