### PR TITLE
Add recovery environment dependency to delphix-platform

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -104,6 +104,12 @@ DEPENDS += delphix-buildinfo-kernel,
 DEPENDS += pam-challenge-response, \
 	   pam-challenge-response-dbgsym,
 
+#
+# The recovery environment is required for the product to be debuggable in
+# worst-case scenarios.
+#
+DEPENDS += recovery-environment,
+
 # Platform-specific dependencies
 DEPENDS.aws = nvme-cli,
 DEPENDS.azure = walinuxagent, linux-cloud-tools-azure,


### PR DESCRIPTION
Small change to add the recovery environment to delphix-platform. ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3727/