### PR TITLE
(WIP) CP-3524 Enable IPv6 at boot time

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -28,14 +28,6 @@ GRUB_SERIAL_COMMAND="serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT mitigations=off"
 
 #
-# Disable IPv6 because it is not supported by the Delphix appliance. We
-# do so here, and not from systemd-sysctl, because while configuring
-# net.ipv6.conf.{default,all}.disable_ipv6 works for the currently
-# installed interfaces, new interfaces don't pick up that parameter.
-#
-GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT ipv6.disable=1"
-
-#
 # On Delphix appliance, disks should have 'noop' I/O scheduler since they
 # would be under ZFS control.
 #


### PR DESCRIPTION
Note: filing this for context when we revisit the IPv6 project. 

This change would allow IPv6 to be enabled at boot-time for a Delphix VM. It is dependent on https://jira.delphix.com/browse/CP-3525 and https://jira.delphix.com/browse/CP-3526 being completed first.

You can read more about the project plan here: 
https://docs.google.com/document/d/1ObUGQxwlzLD5tfIybfvoe2iAPW33R6v8pN2UXs7b9e4/edit#