### PR TITLE
DLPX-69049 [Backport of DLPX-68392 to 6.0.3.0] performance regression on linux kernel 5.3 due to init_on_alloc

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -98,3 +98,18 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT elevator=noop"
 #
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=256M,high"
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=256M,low"
+
+#
+# Disable unnecessary zeroing of allocated pages.
+#
+# The 5.3 linux kernel adds a new feature which allows pages to be
+# zeroed when allocating or freeing them: init_on_alloc and
+# init_on_free. init_on_alloc is enabled by default on Ubuntu. ZFS
+# allocates and frees pages frequently (via the ABD structure), e.g. for
+# every disk access. The additional overhead of zeroing these pages is
+# significant. I measured a ~40% regression in performance of an
+# uncached "zfs send ... >/dev/null".
+#
+# Upstream commit: 6471384af2a6530696fc0203bafe4de41a23c9ef
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT init_on_alloc=0"


### PR DESCRIPTION
Clean cherry-pick of commit from master
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3735/flowGraphTable/ (blacbox failures are unrelated)

perf tests - look good
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/799124/87318417-2709ed80-c4dd-11ea-8847-0ecf889f6cf1.png">
