### PR TITLE
DLPX-70755 Lumen missing ldapsearch

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -121,7 +121,6 @@ DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 # or replaced without regard for backward compatibility.
 #
 DEPENDS += bcc-tools, \
-	   libbcc-dbgsym, \
 	   bpftrace, \
 	   bpftrace-dbgsym, \
 	   crash, \
@@ -140,15 +139,17 @@ DEPENDS += bcc-tools, \
 	   iotop, \
 	   jq, \
 	   kdump-tools, \
-	   makedumpfile-dbgsym, \
-	   mtr, \
+	   ldap-utils, \
+	   libbcc-dbgsym, \
 	   libkdumpfile, \
 	   libkdumpfile-dbgsym, \
 	   lsof, \
+	   makedumpfile-dbgsym, \
 	   man-db, \
 	   manpages, \
 	   manpages-dev, \
 	   memstat, \
+	   mtr, \
 	   ncdu, \
 	   pciutils, \
 	   performance-diagnostics, \


### PR DESCRIPTION
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3754/flowGraphTable/

I cloned an image on dlpxdc.co based on this build and made sure that ldapsearch was installed via ldap-utils.