### PR TITLE
DLPX-70890 [Backport of DLPX-70755 to 6.0.4.0] Lumen missing ldapsearch

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -133,15 +133,16 @@ DEPENDS += bcc-tools, \
 	   iotop, \
 	   jq, \
 	   kdump-tools, \
-	   makedumpfile-dbgsym, \
-	   mtr, \
+	   ldap-utils, \
 	   libkdumpfile, \
 	   libkdumpfile-dbgsym, \
 	   lsof, \
+	   makedumpfile-dbgsym, \
 	   man-db, \
 	   manpages, \
 	   manpages-dev, \
 	   memstat, \
+	   mtr, \
 	   ncdu, \
 	   pciutils, \
 	   performance-diagnostics, \


### PR DESCRIPTION
Backport of #237 

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3769/flowGraphTable/
The upgrade blackbox failure was caused by a QA bug related to Tallaria. QA re-ran that job with Tallaria turned off here: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/5154/