### PR TITLE
DLPX-70835 disable usb-storage device module loading in delphix 6.x

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -113,3 +113,8 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=256M,low"
 # Upstream commit: 6471384af2a6530696fc0203bafe4de41a23c9ef
 #
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT init_on_alloc=0"
+
+#
+# Disable the USB subsystem in its entirety for security reasons.
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT usbcore.nousb=1"


### PR DESCRIPTION
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3794/

I manually tested the grub configuration by making the changes to `/etc/default/grub.d/override.cfg`, mounting `rpool/grub`, and updating the grub configuration there using `grub-mkconfig -o /mnt/boot/grub/grub.cfg`. I rebooted and verified that the setting was correct:
```
# cat /sys/module/usbcore/parameters/nousb
Y
```
And that USB drivers can no longer be loaded:
```
root@guild:~# modprobe usb-storage
modprobe: ERROR: could not insert 'usb_storage': No such device
```

I also performed an upgrade from 6.0.3.0 to 6.1.0.0 and verified that the kernel command-line upon reboot to the new version correctly included `usbcore.nousb=1`.