### PR TITLE
DLPX-70690 GCP upgrade stuck in verifying state with force-not-in-place option

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
@@ -22,4 +22,4 @@
 #
 - command: /usr/bin/google_instance_setup
   listen: "gcp config changed"
-  when: not ansible_is_chroot
+  when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot


### PR DESCRIPTION
Skip running google_instance_setup script within a container since it causes delphix-platform to hang within a container with status like :

```
root@sanbhara-trunk-gcp-2:~# systemctl status delphix-platform
● delphix-platform.service - Delphix Appliance Platform Service
   Loaded: loaded (/lib/systemd/system/delphix-platform.service; enabled; vendor preset: enabled)
   Active: activating (start) since Fri 2020-07-31 19:17:11 UTC; 3h 27min ago
 Main PID: 28102 (apply)
   CGroup: /system.slice/delphix-platform.service
           ├─28102 /bin/bash /var/lib/delphix-platform/ansible/apply
           ├─28115 /usr/bin/python2 /usr/bin/ansible-playbook -vvv -c local -i localhost, -e root_filesystem=rpool/ROOT/delphix.UYhA4Rm/root -e platform=gcp -e variant=internal-qa /var/lib/delphix-platform/ansible/10-delphix-platform/playbook.yml
           ├─29281 /usr/bin/python2 /usr/bin/ansible-playbook -vvv -c local -i localhost, -e root_filesystem=rpool/ROOT/delphix.UYhA4Rm/root -e platform=gcp -e variant=internal-qa /var/lib/delphix-platform/ansible/10-delphix-platform/playbook.yml
           ├─29294 /bin/sh -c /bin/sh -c '/usr/bin/python3 /tmp/ansible-tmp-1596223052.21-29281-168922546943641/AnsiballZ_command.py && sleep 0'
           ├─29295 /bin/sh -c /usr/bin/python3 /tmp/ansible-tmp-1596223052.21-29281-168922546943641/AnsiballZ_command.py && sleep 0
           ├─29296 /usr/bin/python3 /tmp/ansible-tmp-1596223052.21-29281-168922546943641/AnsiballZ_command.py
           └─29297 /usr/bin/python3 /usr/bin/google_instance_setup

Jul 31 19:17:32 sanbhara-trunk-gcp-2 apply[28102]: RUNNING HANDLER [delphix-platform : command] ***********************************
Jul 31 19:17:32 sanbhara-trunk-gcp-2 apply[28102]: task path: /var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml:23
Jul 31 19:17:32 sanbhara-trunk-gcp-2 apply[28102]: <localhost> ESTABLISH LOCAL CONNECTION FOR USER: root
Jul 31 19:17:32 sanbhara-trunk-gcp-2 apply[28102]: <localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /tmp `"&& mkdir /tmp/ansible-tmp-1596223052.21-29281-168922546943641 && echo ansible-tmp-1596223052.21-29281-168922546943641="` echo /tmp/ansible-tmp-1596223052.21-29281-168922546943641 `" ) && sleep 0'
Jul 31 19:17:32 sanbhara-trunk-gcp-2 apply[28102]: Using module file /usr/lib/python2.7/dist-packages/ansible/modules/commands/command.py
Jul 31 19:17:32 sanbhara-trunk-gcp-2 apply[28102]: <localhost> PUT /tmp/ansible-local-28115kIf1U_/tmpiATG0l TO /tmp/ansible-tmp-1596223052.21-29281-168922546943641/AnsiballZ_command.py
Jul 31 19:17:32 sanbhara-trunk-gcp-2 apply[28102]: <localhost> EXEC /bin/sh -c 'chmod u+x /tmp/ansible-tmp-1596223052.21-29281-168922546943641/ /tmp/ansible-tmp-1596223052.21-29281-168922546943641/AnsiballZ_command.py && sleep 0'
Jul 31 19:17:32 sanbhara-trunk-gcp-2 apply[28102]: <localhost> EXEC /bin/sh -c '/usr/bin/python3 /tmp/ansible-tmp-1596223052.21-29281-168922546943641/AnsiballZ_command.py && sleep 0'
Jul 31 19:17:32 sanbhara-trunk-gcp-2 ansible-command[29296]: Invoked with _raw_params=/usr/bin/google_instance_setup warn=True _uses_shell=False stdin_add_newline=True strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None
Jul 31 19:17:37 sanbhara-trunk-gcp-2 instance-setup[29297]: ERROR GET request error retrieving metadata. <urlopen error [Errno -2] Name or service not known>.
```

Testing : 
ab-pre-push : http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3809/

For testing, need to generate an upgrade image with delphix-platform debian package for GCP platform:
git ab-pre-push -p "AWS GCP" -at: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3818/

With an upgrade image from above build, unpacked the image with the -x switch to force not-in-place upgrade. Verification of the image went through fine with delphix-platform service having successfully started within the container.

Went through with the mandatory full upgrade (due to the image being unpacked with the -x switch) and confirmed that the override parameters in "/etc/default/instance_configs.cfg.template " have been applied to "/etc/default/instance_configs.cfg"