### PR TITLE
DLPX-70914 [Backport of DLPX-70835 to 6.0.4.0] disable usb-storage device module loading in delphix 6.x

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -113,3 +113,8 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=256M,low"
 # Upstream commit: 6471384af2a6530696fc0203bafe4de41a23c9ef
 #
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT init_on_alloc=0"
+
+#
+# Disable the USB subsystem in its entirety for security reasons.
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT usbcore.nousb=1"


### PR DESCRIPTION
This is a clean cherry-pick of #240 

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3812/

A similar change will have to be made to appliance-build to cover migrations from 5.3.