### PR TITLE
DLPX-71293 [Backport of DLPX-70690 to 6.0.4.0] GCP upgrade stuck in verifying state with force-not-in-place option

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
@@ -22,4 +22,4 @@
 #
 - command: /usr/bin/google_instance_setup
   listen: "gcp config changed"
-  when: not ansible_is_chroot
+  when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/delphix-platform/pull/242

Testing : 

git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3827/
git ab-pre-push -p "AWS GCP" -a: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3828/

tested upgrade image from latter run to perform a not-in-place upgrade to 6.0.4.0 version VM. Verification and Upgrade went through fine, and /etc/default/instance_configs.cfg file has the updated configuration from /etc/default/instance_configs.cfg.template.