### PR TITLE
DLPX-72409 Management stack fails on first boot on Azure

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -97,11 +97,11 @@ DEPENDS += pam-challenge-response, \
 
 # Platform-specific dependencies
 DEPENDS.aws = nvme-cli,
-DEPENDS.azure = walinuxagent, linux-cloud-tools-azure,
+DEPENDS.azure = walinuxagent,
 DEPENDS.esx = open-vm-tools,
 DEPENDS.gcp = gce-compute-image-packages, python-google-compute-engine, \
 	   python3-google-compute-engine,
-DEPENDS.hyperv = linux-cloud-tools-azure,
+DEPENDS.hyperv =
 DEPENDS.kvm =
 DEPENDS.oci =
 DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))


### PR DESCRIPTION
See JIRA for more info.
This is half of the work, the other half is here: https://github.com/delphix/delphix-kernel/pull/16

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4233/
- ab-pre-push, including changes from https://github.com/delphix/delphix-kernel/pull/16: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4250/
  also verified that for `uname -r == 5.4.0-1026-azure`, only `linux-cloud-tools-5.4.0-1026-azure` is installed, and neither `linux-cloud-tools-5.4.0-1031-azure` nor `linux-cloud-tools-azure` is installed any longer.
