### PR TITLE
DLPX-73666 file "/var/run/reboot-required" is not properly generated on DEFERRED upgrades

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -60,7 +60,8 @@ DEPENDS += ansible, \
 	   python3, \
 	   rng-tools, \
 	   systemd-container, \
-	   ubuntu-minimal,
+	   ubuntu-minimal, \
+	   update-notifier-common,
 
 # Debugging symbols for packages pulled in by the the above dependencies
 DEPENDS += systemd-dbgsym, \


### PR DESCRIPTION
This is a simple change to add the "update-notifier-common" package as a
dependency. This package is required for the "/var/lib/reboot-required"
file to be properly generated during a upgrade of the appliance.