### PR TITLE
Add "update-notifier-common" package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -59,7 +59,8 @@ DEPENDS += ansible, \
 	   python3, \
 	   rng-tools, \
 	   systemd-container, \
-	   ubuntu-minimal,
+	   ubuntu-minimal, \
+	   update-notifier-common,
 
 # Debugging symbols for packages pulled in by the the above dependencies
 DEPENDS += systemd-dbgsym, \


### PR DESCRIPTION
This is a simple change to add the "update-notifier-common" package as a
dependency. This package is required for the "/var/lib/reboot-required"
file to be properly generated during a upgrade of the appliance.