### PR TITLE
DLPX-73192 Establish appropriate systemd service dependencies for iSCSI initiator

### DIFF
--- a/files/common/etc/systemd/system/open-iscsi.service.d/override.conf
+++ b/files/common/etc/systemd/system/open-iscsi.service.d/override.conf
@@ -1,0 +1,10 @@
+#
+# Customize the open-iscsi service to be zfs aware.  When attempting a service
+# stop, check if there are any zpools still actively using iSCSI devices.
+#
+[Service]
+ExecStop=
+ExecStop=/lib/open-iscsi/zpool_on_iscsi.sh
+ExecStop=/lib/open-iscsi/umountiscsi.sh
+ExecStop=/bin/sync
+ExecStop=/lib/open-iscsi/logout-all.sh

--- a/files/common/lib/open-iscsi/zpool_on_iscsi.sh
+++ b/files/common/lib/open-iscsi/zpool_on_iscsi.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 by Delphix. All rights reserved.
+#
+
+#
+# This script checks if any iSCSI devices are in use by an active zfs pool.
+
+PATH=/sbin:/bin
+
+ZFS_FS_TYPE="zfs_member"
+
+function usage() {
+	echo "Usage: $0 [--verbose]" >&2
+	exit 2
+}
+
+if [[ $# -gt 1 ]]; then
+	usage
+fi
+
+VERBOSE=0
+if [[ $# -eq 1 ]]; then
+	if [[ "$1" != "--verbose" ]]; then
+		usage
+	fi
+	VERBOSE=1
+fi
+
+shopt -s nullglob
+
+# locate iscsi devices that belong to a zfs pool
+while read -r type transport device; do
+	# first locate iscsi devices
+	[[ "$type" == "disk" && "$transport" == "iscsi" ]] || continue
+	[[ $VERBOSE -eq 0 ]] || echo "${device} uses iSCSI"
+
+	# locate any partitions for this device
+	for partition in /dev/"${device}"?*; do
+		# check if partition type is zfs and grab the pool name
+		read -r fstype pool <<<"$(lsblk -n -o FSTYPE,LABEL "${partition}")"
+		[[ "$fstype" == "$ZFS_FS_TYPE" && -n "$pool" ]] || continue
+		[[ $VERBOSE -eq 0 ]] || echo " ${partition} is a member of pool ${pool}"
+
+		# check if pool is active (imported)
+		health=$(zpool list -H -o name,health "${pool}" 2>&1)
+		status=$?
+		[[ $VERBOSE -eq 0 ]] || echo "  ${health} ($status)"
+		if [[ $status -eq 0 ]]; then
+			echo "device '${partition}' in use by zfs pool '${pool}'" >&2
+			exit 1
+		fi
+	done
+done < <(lsblk --scsi -n -o TYPE,TRAN,NAME)
+
+exit 0

--- a/files/common/lib/open-iscsi/zpool_on_iscsi.sh
+++ b/files/common/lib/open-iscsi/zpool_on_iscsi.sh
@@ -5,6 +5,7 @@
 
 #
 # This script checks if any iSCSI devices are in use by an active zfs pool.
+#
 
 PATH=/sbin:/bin
 


### PR DESCRIPTION
## Description

This makes the `open-iscsi` service service **stop** operation zfs aware.  Here we want to make sure ZFS is still not actively using an iSCSI device.  When restarting (or stopping) the `open-iscsi` service, the iscsi devices are torn completely down.  Then during start these devices are rebuilt; they typically have a different device node (`sdN`).  Note that an `open-iscsi` **stop** operation already checks for mounted file systems that are backed by iscsi devices but those checks are not ZFS aware.

We introduce a new check script, `zpool_on_iscsi.sh`, which is similar to the existing `umountiscsi.sh` script.  This new script will return a non-zero result (1) if there is a zfs pool using iSCSI devices which in turn will prevent the `open-iscsi` service from stopping.  The service will log the failure as seen below.
```
Jan 14 02:00:04  systemd[1]: Stopping Login to default iSCSI targets...
Jan 14 02:00:04  zpool_on_iscsi.sh [25638]: device '/dev/sde1' in use by zfs pool 'domain0'
Jan 14 02:00:04  systemd[1]: open-iscsi.service: Control process exited, code=exited status=1
Jan 14 02:00:04  systemd[1]: open-iscsi.service: Failed with result 'exit-code'.
```
We expect that most iSCSI administration will be performed using the Delphix iSCSI APIs and that in general no admin should be directly stopping or restarting the `open-iscsi` service.

## Testing Done
Ab-pre-push:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4641/

Manual Testing:
- Confirmed override.conf file was correctly installed and that `systemctl cat` shows override is present
- Confirmed that when the pool is imported, that stopping `open-iscsi` service will fail and the pool remains accessible
- Confirmed that after the domain0 pool is exported, then a stop of `open-iscsi` service proceeds and the iscsi devices are no longer present (`lsblk`).
- Confirmed that on a reboot the system was able to shutdown (i.e. the `zpool_on_iscsi.sh` check doesn't prevent shutting down)
- Ran both `shellcheck` and `shfmt` against the new script.

## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
An `open-iscsi`  stop will tear down the devices while still being used by zfs and the pool will become suspended

## What is the new behavior?
stopping `open-iscsi` service will fail and the pool remains accessible

## Does this introduce a breaking change?
- [ ] Yes
- [x] No