### PR TITLE
Fix several issues with delphix console screen

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,8 @@ jobs:
         with:
           python-version: '3.6'
       - run: python3 -m pip install pylint
-      - run: pylint -d invalid-name files/common/usr/bin/delphix-startup-screen
+      - run: python3 -m pip install netifaces
+      - run: pylint -d invalid-name,E0611 files/common/usr/bin/delphix-startup-screen
   check-yapf:
     runs-on: ubuntu-18.04
     steps:

--- a/files/common/lib/systemd/system/getty@tty1.service.d/override.conf
+++ b/files/common/lib/systemd/system/getty@tty1.service.d/override.conf
@@ -1,6 +1,5 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -t 120 -o '-p -- \\u' --noclear %I $TERM
-ExecStartPre=-/usr/bin/delphix-startup-screen
+ExecStart=-/sbin/agetty -n -l /usr/bin/delphix-startup-screen --noclear %I $TERM
 StandardInput=tty
 StandardOutput=tty

--- a/files/common/lib/systemd/system/serial-getty@ttyS0.service.d/override.conf
+++ b/files/common/lib/systemd/system/serial-getty@ttyS0.service.d/override.conf
@@ -1,6 +1,5 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -t 120 -o '-p -- \\u' --keep-baud 115200,38400,9600 %I $TERM
-ExecStartPre=-/usr/bin/delphix-startup-screen
+ExecStart=-/sbin/agetty -n -l /usr/bin/delphix-startup-screen --keep-baud 115200,38400,9600 %I $TERM
 StandardInput=tty
 StandardOutput=tty

--- a/files/common/usr/bin/delphix-startup-screen
+++ b/files/common/usr/bin/delphix-startup-screen
@@ -23,10 +23,12 @@ import curses
 import curses.ascii
 import curses.textpad
 import sys
+import signal
 import os
 import logging
 import subprocess
 from typing import List, Any, Tuple, Generator
+from netifaces import interfaces, ifaddresses, AF_INET
 
 STATUS_HEADER: str = "STATUS\t\t\tSERVICE\t\t\t"
 LAYOUT_STR: str = "Keyboard layout (press 9 to change):"
@@ -201,6 +203,11 @@ def getstatus() -> str:
     status = ""
     for i in getstatus_pair(list(run_svcs("Description"))):
         #
+        # Don't print any inactive services
+        #
+        if i[-1].strip() == "inactive":
+            continue
+        #
         # Switch the state and description
         #
         status += f"{i[-1]}\t{i[0]}\n"
@@ -209,22 +216,17 @@ def getstatus() -> str:
 
 def get_network_status() -> Tuple[str, str]:
     """
-    Returns a tuple of (hostname, ipaddr) for the main interface.
+    Returns a tuple of (hostname, ipaddrs).
     """
 
-    #
-    # We get the primary address based on the default route. The
-    # address we use follows the 'src' key in the output.
-    #
-    cmd = ['ip', 'route', 'show', '0.0.0.0/0']
-    cp = subprocess.run(cmd,
-                        stdout=subprocess.PIPE,
-                        universal_newlines=True,
-                        check=True)
-    output = cp.stdout.split()
-    ipaddr = output[output.index("src") + 1]
+    ipaddrs = []
+    for interface in interfaces():
+        if interface == "lo":
+            continue
+        for link in ifaddresses(interface)[AF_INET]:
+            ipaddrs.append(link['addr'])
     hostname = os.uname()[1]
-    return (hostname, ipaddr)
+    return (hostname, ", ".join(ipaddrs))
 
 
 # pylint: disable-msg=too-many-locals
@@ -239,11 +241,11 @@ def display_status(stdscr, win):
     layout = get_keyboard_layout()
 
     width = X - 10
-    height = Y - 8
+    height = Y - 6
     status = 0
 
     x = int((X - width) / 2) + 2
-    y = (Y - height - 1)
+    y = (Y - height)
 
     win.clear()
     win.box()
@@ -270,10 +272,12 @@ def display_status(stdscr, win):
         sys.stdout.flush()
         sys.stderr.flush()
 
-        (hostname, ipaddr) = get_network_status()
+        (hostname, ipaddrs) = get_network_status()
         netwin.clear()
-        netwin.addstr(0, 0, "Host: http://" + hostname + "/", curses.A_BOLD)
-        netwin.addstr(1, 0, "IP: " + ipaddr, curses.A_BOLD)
+        if hostname:
+            hostname = "https://" + hostname
+        netwin.addstr(0, 0, "Host: " + hostname, curses.A_BOLD)
+        netwin.addstr(1, 0, "IPs: " + ipaddrs, curses.A_BOLD)
         netwin.noutrefresh()
 
         # We get status every 10 secs
@@ -373,7 +377,7 @@ def display_keyboard_layout_selection(stdscr, win):
 #
 # Main function.
 #
-def installer_main(stdscr):
+def console_main(stdscr):
     """
     Main
     """
@@ -389,6 +393,27 @@ def installer_main(stdscr):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(filename=log_file, level=logging.DEBUG)
+    #
+    # We need to ensure that any errors in the rest of the script won't
+    # prevent us from logging into the system.
+    #
+    try:
+        logging.basicConfig(filename=log_file, level=logging.DEBUG)
 
-    curses.wrapper(installer_main)
+        #
+        # Since we are going to invoke the login process directly
+        # from the startup screen, we want to ensure that we ignore
+        # any signals which would cause the status screen to restart.
+        # This way the login prompt behaves the same as if it were
+        # invoked from the getty service.
+        #
+        signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        signal.signal(signal.SIGTSTP, signal.SIG_IGN)
+        signal.signal(signal.SIGHUP, signal.SIG_IGN)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGQUIT, signal.SIG_IGN)
+
+        curses.wrapper(console_main)
+    finally:
+        login_cmd: List[str] = ['/bin/login', '-p']
+        subprocess.run(login_cmd, shell=False, check=True)


### PR DESCRIPTION
DLPX-71998 Chatty systemd events for getty, serial-getty services take up a large percentage of syslog
DLPX-72681 delphix-startup-screen fails with static IP address
DLPX-73286 systemd is restarting locale service every 30 seconds
DLPX-73423 delphix-startup-screen crashes if there's no default route

This changes the getty services to launch the startups screen directly and it's the startup screen that invokes login. This prevents the need for the getty service to restart itself frequently and now the localed and getty restarts only happen when the login session is completed. If nobody logs in via the console then we don't need to restart the service. A further enhancement would be to not display the keyboard layout on the main screen. This would prevent localed from starting unless you change the keyboard layout.