### PR TITLE
DLPX-74725 Enable debug for code added for DLPX-72065

### DIFF
--- a/files/common/var/lib/delphix-platform/dynamic-debug
+++ b/files/common/var/lib/delphix-platform/dynamic-debug
@@ -11,6 +11,7 @@ cat <<-EOF >/sys/kernel/debug/dynamic_debug/control
 	# iSCSI debug info related to LUN RESETs and iSCSI reconnects.
 	file target_core_tmr.c +p
 	func iscsit_release_commands_from_conn +p
+	func iscsit_handle_dataout_timeout +p
 EOF
 
 echo "pr_debug statements enabled:"


### PR DESCRIPTION
I've added a new `pr_debug` statement in the iSCSI target driver in https://github.com/delphix/linux-kernel-generic/pull/5.

This PR enables this debug statement by default.

To be more precise, when an aborted iSCSI command has a DataOut timeout we will see the following message in kern.log:
```
DataOut timeout on interrupted cmd with ITT[0xcb6fef00]
```

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4876
- Manual testing from https://github.com/delphix/linux-kernel-generic/pull/5.