### PR TITLE
DLPX-74872 [Backport of DLPX-74859 to 6.0.8.0] Stack fails to come up for GCP engines because delphix-platform service failed

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
@@ -17,9 +17,11 @@
 
 ---
 #
-# Apply any changes made to the override instance config file. This
+# Apply any changes made to the instance config file. This
 # can only be done when we're on a running gcp instance.
 #
-- command: /usr/bin/google_instance_setup
+- systemd:
+    name: google-guest-agent
+    state: restarted
   listen: "gcp config changed"
   when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -307,13 +307,18 @@
   when: platform == "azure"
 
 #
-# Customize the GCP linux environment.
+# Customize the GCP linux environment. We remove any old template
+# and configuration files if they exist.
 #
-# Update the override file for the GCP instance. This file gets
-# applied dynamically by running google_instance_setup script.
-#
+- file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /etc/default/instance_configs.cfg.template
+    - /etc/default/instance_configs.cfg
+
 - blockinfile:
-    path: /etc/default/instance_configs.cfg.template
+    path: /etc/default/instance_configs.cfg
     create: yes
     block: |
       #
@@ -333,14 +338,6 @@
   when:
     - platform == "gcp"
   notify: "gcp config changed"
-
-#
-# Make sure that the account daemon is always disabled. The override file
-# above should prevent this and this is designed to catch any corner cases.
-#
-- command: systemctl disable google-accounts-daemon.service
-  when:
-    - platform == "gcp"
 
 #
 # We want the ssh service to start as early as possible during boot up,


### PR DESCRIPTION
Clean cherry-pick 

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5027/