### PR TITLE
TOOL-10945 Add SSH keys to OCI instances using cloud init

### DIFF
--- a/files/oci/etc/cloud/cloud.cfg.d/99-delphix-datasource.cfg
+++ b/files/oci/etc/cloud/cloud.cfg.d/99-delphix-datasource.cfg
@@ -1,0 +1,1 @@
+datasource_list: [ OpenStack ]

--- a/files/oci/var/lib/cloud/seed/nocloud/meta-data
+++ b/files/oci/var/lib/cloud/seed/nocloud/meta-data
@@ -1,1 +1,0 @@
-{instance-id: iid-system-uuid}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Currently, it is not possible to add ssh keys to our internal variants on OCI. This is because we have been using NoCloud as the cloud-init datasource.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR changes the behavior for the internal variants by allowing OCI to use the OpenStack datasource.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
