### PR TITLE
DLPX-75265 Remove crash-util from the product

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -115,7 +115,6 @@ DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 DEPENDS += bcc-tools, \
 	   bpftrace, \
 	   bpftrace-dbgsym, \
-	   crash, \
 	   crash-python, \
 	   dnsutils, \
 	   drgn, \


### PR DESCRIPTION
# Description

The motivation for this change is two-fold:
- We don't really need this package anymore - we have sdb and crash-python
- We currently have our own downstream branch of crash-util and it is a maintenance burden

This is the first out of 3 changes that will take place throughout
our Delphix repos on github. In this change we just remove the
dependency of the product on crash-util so it stops being installed
on our VMs.

Future work includes stop building the package in linux pkg and
finally deleting our downstream repo. [The deletion of the repo
will have to be delayed though as we may still want to build some
older releases occasionally if the need arises for a support case.]

# Testing

### Automated Testing

ab-pre-push:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5042/

(Note: Integration test failures above are unrelated - one is relevant to a breaking zpool-status change in ZFS, the other one is some core dump generated by alerts in the appstack).

### Manual Testing

In one of my ESX VMs I see the following:
```
delphix@localhost:~$ apt-rdepends -r crash
Reading package lists... Done
Building dependency tree
Reading state information... Done
crash
  Reverse Depends: delphix-platform-esx (1.0.0-delphix-2021.03.12.01)
delphix-platform-esx
delphix@localhost:~$ apt-cache depends delphix-platform-esx | grep crash
  Depends: crash
  Depends: crash-python
```

Cloning a VM on AWS from the image generated from the ab-pre-push above:
```
delphix@ip-10-110-238-139:~$ apt-cache depends delphix-platform-aws | grep crash
  Depends: crash-python
```