### PR TITLE
DLPX-75332 [Backport of DLPX-75265 to 6.0.9.0] Remove crash-util from the product

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -114,7 +114,6 @@ DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 DEPENDS += bcc-tools, \
 	   bpftrace, \
 	   bpftrace-dbgsym, \
-	   crash, \
 	   crash-python, \
 	   dnsutils, \
 	   drgn, \


### PR DESCRIPTION
### Original PR

https://github.com/delphix/delphix-platform/pull/282

### Testing

Automation: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5085/

Manual Testing: TBA once the above ab-pre-push finishes