### PR TITLE
DLPX-72326 Use OOMD instead of the kernel's OOM killer

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -118,3 +118,15 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT init_on_alloc=0"
 # Disable the USB subsystem in its entirety for security reasons.
 #
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT usbcore.nousb=1"
+
+#
+# Enable cgroups v2
+#
+# At the time of this writing we are using Ubuntu 18.04 which has
+# support for cgroups v2 but it is not enabled by default. We can
+# consider removing this when we move to future releases.
+#
+# The appstack doesn't have any hard requirements in the cgroup
+# version but OOMD needs the system to use v2 so it can operate.
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT systemd.unified_cgroup_hierarchy=1"


### PR DESCRIPTION
# Context:
Link: https://facebookmicrosites.github.io/oomd/

OOMD only works with 5.0+ kernels because it needs the PSI kernel interface (we should be good in terms of that) and cgroups V2 hierarchies (I think we are currently V1 so we may have to look into that). The proposal to use this is to overcome difficulties that we have with the current in-kernel OOM killer. Currently when a process dies by the OOM killer:

* It is hard to tell whose fault it was. Was it the application asking for too much memory, or was it that the process had an unfortunate OOM score and was being starved by one or more other processes?
* If it was the process's fault a SIGKILL is sent which is not very useful. We currently have custom logic for the appstack process to generate a core dump so we can analyze where the memory went. If this is any other process we don't have that luxury.
* If it was some kind of systemic failure due to many small processes starving the appstack or similar, we had no idea if, how, or why such thing happened.

OOMD is very flexible and configurable. It can deal with all of the above by being configured to send SIGABRTs (and generate crash dumps) when processes take too much memory, take a system-wide memory snapshot before killing a process, and enforce per-process memory limits.

# This Patch:
Enables CGROUPs v2 for the appstack by setting a kernel parameter during boot through GRUB.

# Testing:
I created a VM and passed it that kernel parameter. The I manually checked that we had switched to cgroupsv2 by looking at the cgroup directory under sysfs.

= Before the patch:
```
$ ls /sys/fs/cgroup/memory
cgroup.clone_children           memory.kmem.tcp.limit_in_bytes      memory.stat
cgroup.event_control            memory.kmem.tcp.max_usage_in_bytes  memory.swappiness
cgroup.procs                    memory.kmem.tcp.usage_in_bytes      memory.usage_in_bytes
cgroup.sane_behavior            memory.kmem.usage_in_bytes          memory.use_hierarchy
memory.failcnt                  memory.limit_in_bytes               notify_on_release
memory.force_empty              memory.max_usage_in_bytes           release_agent
memory.kmem.failcnt             memory.move_charge_at_immigrate     system.slice
memory.kmem.limit_in_bytes      memory.numa_stat                    tasks
memory.kmem.max_usage_in_bytes  memory.oom_control                  user.slice
memory.kmem.slabinfo            memory.pressure_level
memory.kmem.tcp.failcnt         memory.soft_limit_in_bytes
```
= After the patch (`memory` directory is gone as it is unified under the top-level `cgroup` directory in v2):
```
$ ls /sys/fs/cgroup/memory
ls: cannot access '/sys/fs/cgroup/memory': No such file or directory
$ ls /sys/fs/cgroup/
cgroup.controllers      cgroup.stat             cpuset.cpus.effective  io.cost.qos      user.slice
cgroup.max.depth        cgroup.subtree_control  cpuset.mems.effective  io.pressure
cgroup.max.descendants  cgroup.threads          init.scope             memory.pressure
cgroup.procs            cpu.pressure            io.cost.model          system.slice
```

The only service that had a problem starting was our existing OOM service which we wrote with the assumption of using cgroups v1:
```
$ sudo systemctl list-units --failed
  UNIT                        LOAD   ACTIVE SUB    DESCRIPTION
● delphix-oom-handler.service loaded failed failed OOM handler for delphix-mgmt.service

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.

1 loaded units listed. Pass --all to see loaded but inactive units, too.
To show all installed unit files use 'systemctl list-unit-files'.
```

So I disabled it and run dx-test on that VM:
```
$ sudo systemctl stop delphix-oom-handler
$ sudo systemctl disable delphix-oom-handler
Removed /etc/systemd/system/delphix-mgmt.service.wants/delphix-oom-handler.service.
$ sudo systemctl daemon-reload
$ sudo systemctl reset-failed
```

dx-test:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/dx-integration-tests/23953/

the BB section of the above failed because of how I specified my VM `sd-bpf` instead of `sd-bpf.dcol2` so I re-run the BB part:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-self-service/89831/

# Future Work

I still need to:
- Ensure that cgroups v2 does not break the containers used in upgrade or `docker` used by the vSDK project (cc: @nhlien93)
- Add OOMD to our list of packages (cc: @pzakha)
- Create a commit that replaces our current OOM service with OOMD (cc: @johngallagher-dlpx)
