### PR TITLE
DLPX-74871 [Backport of DLPX-74808 to 6.0.9.0] Add SSH keys to OCI instances using cloud init

### DIFF
--- a/files/oci/etc/cloud/cloud.cfg.d/99-delphix-datasource.cfg
+++ b/files/oci/etc/cloud/cloud.cfg.d/99-delphix-datasource.cfg
@@ -1,0 +1,1 @@
+datasource_list: [ OpenStack ]

--- a/files/oci/var/lib/cloud/seed/nocloud/meta-data
+++ b/files/oci/var/lib/cloud/seed/nocloud/meta-data
@@ -1,1 +1,0 @@
-{instance-id: iid-system-uuid}


### PR DESCRIPTION
Clean cherry-pick

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5269/