### PR TITLE
DLPX-73229 iSCSI initiator name should be unique on each engine

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 #
-# Copyright 2018, 2019 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ configure)
 	systemctl enable delphix.target
 	systemctl enable delphix-platform.service
 	systemctl enable systemd-networkd.service
+	systemctl enable iscsi-name-init.service
 
 	if ! id -u postgres >/dev/null; then
 		# When installing postgres, a postgres user is created unless it

--- a/files/common/lib/open-iscsi/unique-name-check.sh
+++ b/files/common/lib/open-iscsi/unique-name-check.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 by Delphix. All rights reserved.
+#
+
+#
+# This script generates a unique initiator name based on the system-uuid
+#
+
+PATH=/bin:/usr/bin/
+
+NAME_FILE="/etc/iscsi/initiatorname.iscsi"
+AUTHORITY="2008-07.com.delphix"
+
+if [[ -f $NAME_FILE ]]; then
+	system_uuid=$(get-system-uuid)
+
+	if [[ ${#system_uuid} -ne 36 ]]; then
+		echo "Error: unexpected UUID -- $system_uuid" >&2
+		exit 1
+	fi
+
+	name_entry="InitiatorName=iqn.$AUTHORITY:$system_uuid"
+
+	#
+	# Generate IQN for this Delphix Engine (if not already present)
+	#
+	if ! grep -Gq "^$name_entry" $NAME_FILE; then
+		{
+			echo "## DO NOT EDIT OR REMOVE THIS FILE!"
+			echo "## If you remove this file, the iSCSI daemon will not start."
+			echo "## If you change the InitiatorName, existing access control lists"
+			echo "## may reject this initiator.  The InitiatorName must be unique"
+			echo "## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames."
+			printf '%s\n' "$name_entry"
+		} >$NAME_FILE
+		chmod 640 $NAME_FILE
+		echo "Generating unique iSCSI name using UUID $system_uuid"
+	fi
+fi
+
+exit 0

--- a/files/common/lib/systemd/system/iscsi-name-init.service
+++ b/files/common/lib/systemd/system/iscsi-name-init.service
@@ -1,0 +1,27 @@
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[Unit]
+Description=One time IQN configuration for iscsid.service
+Before=open-iscsi.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/lib/open-iscsi/unique-name-check.sh
+
+[Install]
+WantedBy=open-iscsi.service

--- a/files/common/usr/bin/get-system-uuid
+++ b/files/common/usr/bin/get-system-uuid
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PATH=/bin:/usr/bin/:/usr/sbin
+
+set -o pipefail
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+
+if [[ $# -ne 0 ]]; then
+	echo "Error: unexpected arguments"
+	echo "Usage: $(basename "$0")"
+	echo
+	echo "Display the persistent system uuid for the appliance."
+	exit 2
+fi
+
+#
+# Extract the 'system-uuid' property.
+#
+# This property is used for an engine-uuid as well as to derive
+# a unique iSCSI initiator IQN.
+#
+# NOTE:
+# IBMcloud changes the system-uuid whenever the engine is
+# power-cycled but preserves the chassis-asset-tag-uuid. For that
+# cloud provider we use that property to obtain a UUID.
+#
+if [[ "$(dmidecode -s chassis-asset-tag)" == "ibmcloud" ]]; then
+	DMI_KEYWORD="baseboard-asset-tag"
+else
+	DMI_KEYWORD="system-uuid"
+fi
+
+system_uuid=$(dmidecode -s $DMI_KEYWORD | awk '{print tolower($0)}')
+
+echo -n "$system_uuid"
+exit 0


### PR DESCRIPTION
# Problem:
On Ubuntu, the Initiator IQN is generated when the `open-iscsi` package is installed.  However, we want a unique IQN name to be generated on first boot.  We also want the name generation to not be dependent on performing any iSCSI initiator setup (e.g. the unique IQN should be ready before discovery phase).
# Solution:
Added a new service, `iscsi-name-init.service`, that runs at boot time to generate a unique IQN. This service runs a new script, `unique-name-check`, that will generate a unique initiator IQN.

This new service is based on the Fedora,[ First-time Service Setup](https://docs.fedoraproject.org/en-US/packaging-guidelines/Initial_Service_Setup/) model.
# Testing
ab-pre-push:
  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5270/
pre_checkin:
  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-self-service/91842/consoleFull

Manual testing to confirmed that:
- after first boot a new engine UUID based IQN is generated.
- after subsequent boots the name is no longer changing
- cloning an engine with an existing engine UUID based IQN will generate a new IQN that matches the new engine UUID

Here is expected log output for the new service
```
delphix@djb-master-uniq-iqn:~$ sudo journalctl -u iscsi-name-init
-- Logs begin at Thu 2021-05-13 19:33:19 UTC, end at Thu 2021-05-13 21:18:59 UTC. --
May 13 19:33:41 localhost systemd[1]: Starting One time IQN configuration for iscsid.service...
May 13 19:33:53 djb-master-uniq-iqn.dcol1 unique-name-check.sh[1836]: Generating unique iSCSI name for engine 564d7744-7deb-3c35-9882-fb2fd4d01a63
May 13 19:33:53 djb-master-uniq-iqn.dcol1 systemd[1]: Started One time IQN configuration for iscsid.service.
```
# Implementation:
Note that the `open-iscsi` service and `iscsid` service don't run until iSCSI is configured (i.e. a target is discovered), so we can't use them to run our `unique-name-check` script.

The initiator IQN is based on the unique engine UUID. This engine UUID is unique after first boot and after an existing engine is cloned.

An example IQN looks like:  `iqn.2008-07.com.delphix:564d7744-7deb-3c35-9882-fb2fd4d01a63`

NOTE:  since the `/etc/engine-UUID` file is written during the startup of `delphix-mgmt` service and the `iscsi-name-init` service occurs earlier, we use the `bos_mgmt` `get_system_uuid` command to obtain the engine id sooner.