### PR TITLE
CP-5096 Revert delphix-platform change

### DIFF
--- a/files/common/usr/lib/sysctl.d/30-nfsv3-ports.conf
+++ b/files/common/usr/lib/sysctl.d/30-nfsv3-ports.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2020, 2021 Delphix
+# Copyright 2020 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,5 @@
 # 54043 RPC mountd listen
 # 54044 RPC statd listen
 # 54045 RPC lockd/nlockmgr
-# 54046 Virtualization SDK Libs Server
 #
-net.ipv4.ip_local_reserved_ports = 54043-54046
+net.ipv4.ip_local_reserved_ports = 54043-54045


### PR DESCRIPTION
Problem
The docker runtime project no longer needs to reserve a port for the Virtualization SDK Libs Server.

Solution
We are reverting this commit because we switched the communication mechanism for gRPC over to Unix Domain Sockets, and reserving ports are no longer a required change.
