### PR TITLE
[Backport of DLPX-73229 to 6.0.9.0] iSCSI initiator name should be unique on each engine

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 #
-# Copyright 2018, 2019 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ configure)
 	systemctl enable delphix.target
 	systemctl enable delphix-platform.service
 	systemctl enable systemd-networkd.service
+	systemctl enable iscsi-name-init.service
 
 	#
 	# Only enable the delphix-migration service on initial install, not

--- a/files/common/lib/open-iscsi/unique-name-check.sh
+++ b/files/common/lib/open-iscsi/unique-name-check.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 by Delphix. All rights reserved.
+#
+
+#
+# This script generates a unique initiator name based on the system-uuid
+#
+
+PATH=/bin:/usr/bin/
+
+NAME_FILE="/etc/iscsi/initiatorname.iscsi"
+AUTHORITY="2008-07.com.delphix"
+
+if [[ -f $NAME_FILE ]]; then
+	system_uuid=$(get-system-uuid)
+
+	if [[ ${#system_uuid} -ne 36 ]]; then
+		echo "Error: unexpected UUID -- $system_uuid" >&2
+		exit 1
+	fi
+
+	name_entry="InitiatorName=iqn.$AUTHORITY:$system_uuid"
+
+	#
+	# Generate IQN for this Delphix Engine (if not already present)
+	#
+	if ! grep -Gq "^$name_entry" $NAME_FILE; then
+		{
+			echo "## DO NOT EDIT OR REMOVE THIS FILE!"
+			echo "## If you remove this file, the iSCSI daemon will not start."
+			echo "## If you change the InitiatorName, existing access control lists"
+			echo "## may reject this initiator.  The InitiatorName must be unique"
+			echo "## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames."
+			printf '%s\n' "$name_entry"
+		} >$NAME_FILE
+		chmod 640 $NAME_FILE
+		echo "Generating unique iSCSI name using UUID $system_uuid"
+	fi
+fi
+
+exit 0

--- a/files/common/lib/systemd/system/iscsi-name-init.service
+++ b/files/common/lib/systemd/system/iscsi-name-init.service
@@ -1,0 +1,27 @@
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[Unit]
+Description=One time IQN configuration for iscsid.service
+Before=open-iscsi.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/lib/open-iscsi/unique-name-check.sh
+
+[Install]
+WantedBy=open-iscsi.service

--- a/files/common/usr/bin/get-system-uuid
+++ b/files/common/usr/bin/get-system-uuid
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PATH=/bin:/usr/bin/:/usr/sbin
+
+set -o pipefail
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+
+if [[ $# -ne 0 ]]; then
+	echo "Error: unexpected arguments"
+	echo "Usage: $(basename "$0")"
+	echo
+	echo "Display the persistent system uuid for the appliance."
+	exit 2
+fi
+
+#
+# Extract the 'system-uuid' property.
+#
+# This property is used for an engine-uuid as well as to derive
+# a unique iSCSI initiator IQN.
+#
+# NOTE:
+# IBMcloud changes the system-uuid whenever the engine is
+# power-cycled but preserves the chassis-asset-tag-uuid. For that
+# cloud provider we use that property to obtain a UUID.
+#
+if [[ "$(dmidecode -s chassis-asset-tag)" == "ibmcloud" ]]; then
+	DMI_KEYWORD="baseboard-asset-tag"
+else
+	DMI_KEYWORD="system-uuid"
+fi
+
+system_uuid=$(dmidecode -s $DMI_KEYWORD | awk '{print tolower($0)}')
+
+echo -n "$system_uuid"
+exit 0


### PR DESCRIPTION
Clean cherry pick from DLPX-73229 (#300) from commit ec65abf8458ac8fa75daca69b8d1ad489227f82f

Tested with ab-pre-push 
  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5386/