### PR TITLE
DLPX-76570 [Backport of DLPX-76340 to 6.0.10.0] Install new delphix-build-info package on Delphix Appliance

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -107,6 +107,13 @@ DEPENDS.oci =
 DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 
 #
+# The delphix-build-info package contains build metadata related to the
+# packages built by Delphix and to the appliance itself. While it is there
+# mostly for human convenience, it may be used by some QA tests.
+#
+DEPENDS += delphix-build-info,
+
+#
 # These packages are tools that are intended for human convenience. The
 # product should not rely on them programmatically. They may be updated
 # or replaced without regard for backward compatibility.


### PR DESCRIPTION
Clean cherry-pick of #306 

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5726/