### PR TITLE
DLPX-76623 Remove python-sh package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -85,13 +85,6 @@ DEPENDS += systemd-dbgsym, \
 DEPENDS += ubuntu-dbgsym-keyring,
 
 #
-# sh module for python. This is not currently used by any utility but is
-# left here for convenience. It was previously used by migrationctl.
-#
-DEPENDS += python3-sh, \
-	   python-sh,
-
-#
 # The CRA PAM module provides an authentication method for the delphix user.
 #
 DEPENDS += pam-challenge-response, \


### PR DESCRIPTION
Remove python-sh and python3-sh packages.

They were previously used by the migrationctl utility, but are not used anymore. We need to remove the python2 version of the package, python-sh, since it is no longer available on Ubuntu 20.04. I've decided to remove python3-sh as well with the goal of removing unused packages from our appliance.

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5747/