### PR TITLE
DLPX-76534 Docker0 NIC gets created after upgrade from 6.0/release to 6.0/stage or 6.0/stage to trunk

### DIFF
--- a/files/common/lib/systemd/system/delphix-platform.service
+++ b/files/common/lib/systemd/system/delphix-platform.service
@@ -18,7 +18,7 @@
 Description=Delphix Appliance Platform Service
 PartOf=delphix.target
 After=local-fs.target
-Before=rsync.service
+Before=rsync.service docker.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This fix needs to be pushed along with the appgate review to this change which changes when the docker service gets started for the very first time to only after the delphix-platform package has been started and therefore the correct config has been written to the engine.