### PR TITLE
DLPX-76772 [Backport of DLPX-76623 to 6.0.10.0] Remove python-sh package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -85,12 +85,6 @@ DEPENDS += systemd-dbgsym, \
 DEPENDS += ubuntu-dbgsym-keyring,
 
 #
-# sh module for python. This is currently used by the migrationctl utility.
-#
-DEPENDS += python3-sh, \
-	   python-sh,
-
-#
 # The CRA PAM module provides an authentication method for the delphix user.
 #
 DEPENDS += pam-challenge-response, \


### PR DESCRIPTION
Cherry-pick of #310 

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5807/