### PR TITLE
(Tests pending) TOOL-11960 Install ca-certifcates to delphix-platform such that openjdk11 can install

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,6 +89,11 @@ DEPENDS += ubuntu-dbgsym-keyring,
 #
 DEPENDS += pam-challenge-response, \
 	   pam-challenge-response-dbgsym,
+
+#
+# The ca-certificates-java module is a dependency for OpenJDK 11.
+#
+DEPENDS += ca-certificates-java,
 
 # Platform-specific dependencies
 DEPENDS.aws = nvme-cli,


### PR DESCRIPTION
**Background:**

As part of [TOOL-11707](https://jira.delphix.com/browse/TOOL-11707), we are trying to install Java 11 on the DCoL hosts because the Jenkins project is planning on deprecating Java 8 support in the near future. DCoL is used as a Jenkins agent.

**Problem:**

When testing TOOL-11707, I tried to install `openjdk11` but I kept receiving this error:

```
18:37:05  task path: /var/tmp/jenkins/workspace/devops-gate/master/appliance-build-stage1/post-push/appliance-build/live-build/misc/ansible-roles/appliance-build.dcenter/tasks/main.yml:51
18:38:15  FAILED - RETRYING: appliance-build.dcenter : apt (3 retries left).
18:39:53  FAILED - RETRYING: appliance-build.dcenter : apt (2 retries left).
18:41:32  FAILED - RETRYING: appliance-build.dcenter : apt (1 retries left).
18:43:26  fatal: <binary>: FAILED! => {"attempts": 3, "cache*update_time": 1627609377, "cache_updated": true, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"      install 'openjdk-11-jdk-headless'' failed: E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)\nhead: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory\nthe keytool command requires a mounted proc fs (/proc).\ndpkg: error processing package ca-certificates-java (--configure):\n installed ca-certificates-java package post-installation script subprocess returned error exit status 1\ndpkg: dependency problems prevent configuration of openjdk-11-jre-headless:amd64:\n openjdk-11-jre-headless:amd64 depends on ca-certificates-java; however:\n  Package ca-certificates-java is not configured yet.\n\ndpkg: error processing package openjdk-11-jre-headless:amd64 (--configure):\n dependency problems - leaving unconfigured\ndpkg: dependency problems prevent configuration of openjdk-11-jdk-headless:amd64:\n openjdk-11-jdk-headless:amd64 depends on openjdk-11-jre-headless (= 11.0.11<ins>9-0ubuntu2<sub>18.04); however:\n  Package openjdk-11-jre-headless:amd64 is not configured yet.\n\ndpkg: error processing package openjdk-11-jdk-headless:amd64 (--configure):\n dependency problems - leaving unconfigured\nthe keytool command requires a mounted proc fs (/proc).\nErrors were encountered while processing:\n ca-certificates-java\n openjdk-11-jre-headless:amd64\n openjdk-11-jdk-headless:amd64\nE: Sub-process /usr/bin/dpkg returned an error code (1)\n", "rc": 100, "stderr": "E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)\nhead: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory\nthe keytool command requires a mounted proc fs (/proc).\ndpkg: error processing package ca-certificates-java (--configure):\n installed ca-certificates-java package post-installation script subprocess returned error exit status 1\ndpkg: dependency problems prevent configuration of openjdk-11-jre-headless:amd64:\n openjdk-11-jre-headless:amd64 depends on ca-certificates-java; however:\n  Package ca-certificates-java is not configured yet.\n\ndpkg: error processing package openjdk-11-jre-headless:amd64 (--configure):\n dependency problems - leaving unconfigured\ndpkg: dependency problems prevent configuration of openjdk-11-jdk-headless:amd64:\n openjdk-11-jdk-headless:amd64 depends on openjdk-11-jre-headless (= 11.0.11</ins>9-0ubuntu2</sub>18.04); however:\n  Package openjdk-11-jre-headless:amd64 is not configured yet.\n\ndpkg: error processing package openjdk-11-jdk-headless:amd64 (--configure):\n dependency problems - leaving unconfigured\nthe keytool command requires a mounted proc fs (/proc).\nErrors were encountered while processing:\n ca-certificates-java\n openjdk-11-jre-headless:amd64\n openjdk-11-jdk-headless:amd64\nE: Sub-process /usr/bin/dpkg returned an error code (1)\n", "stderr_lines": <"E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)", "head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory", "the keytool command requires a mounted proc fs (/proc).", "dpkg: error processing package ca-certificates-java (--configure):", " installed ca-certificates-java package post-installation script subprocess returned error exit status 1", "dpkg: dependency problems prevent configuration of openjdk-11-jre-headless:amd64:", " openjdk-11-jre-headless:amd64 depends on ca-certificates-java; however:", "  Package ca-certificates-java is not configured yet.", "", "dpkg: error processing package openjdk-11-jre-headless:amd64 (--configure):", " dependency problems - leaving unconfigured", "dpkg: dependency problems prevent configuration of openjdk-11-jdk-headless:amd64:", " openjdk-11-jdk-headless:amd64 depends on openjdk-11-jre-headless (= 11.0.11<ins>9-0ubuntu2<sub>18.04); however:", "  Package openjdk-11-jre-headless:amd64 is not configured yet.", "", "dpkg: error processing package openjdk-11-jdk-headless:amd64 (--configure):", " dependency problems - leaving unconfigured", "the keytool command requires a mounted proc fs (/proc).", "Errors were encountered while processing:", " ca-certificates-java", " openjdk-11-jre-headless:amd64", " openjdk-11-jdk-headless:amd64", "E: Sub-process /usr/bin/dpkg returned an error code (1)">, "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nopenjdk-11-jdk-headless is already the newest version (11.0.11</ins>9-0ubuntu2</sub>18.04).\n0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.\n3 not fully installed or removed.\nAfter this operation, 0 B of additional disk space will be used.\nSetting up ca-certificates-java (20180516ubuntu1<sub>18.04.1) ...\nProcessing triggers for ca-certificates (20210119</sub>18.04.1) ...\nUpdating certificates in /etc/ssl/certs...\n0 added, 0 removed; done.\nRunning hooks in /etc/ca-certificates/update.d...\n\nE: /etc/ca-certificates/update.d/jks-keystore exited with code 1.\ndone.\n", "stdout*lines": <"Reading package lists...", "Building dependency tree...", "Reading state information...", "openjdk-11-jdk-headless is already the newest version (11.0.11+9-0ubuntu2<sub>18.04).", "0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.", "3 not fully installed or removed.", "After this operation, 0 B of additional disk space will be used.", "Setting up ca-certificates-java (20180516ubuntu1</sub>18.04.1) ...", "Processing triggers for ca-certificates (20210119<sub>18.04.1) ...", "Updating certificates in /etc/ssl/certs...", "0 added, 0 removed; done.", "Running hooks in /etc/ca-certificates/update.d...", "", "E: /etc/ca-certificates/update.d/jks-keystore exited with code 1.", "done.">}
```

As @basil mentions in [this GitHub PR comment](https://github.com/delphix/appliance-build/pull/576#pullrequestreview-719148521), adding `ca-certificates-java` to the delphix-platform package list should resolve this.

The current workaround is to install `adoptopenjdk-java11-jdk` but this install is Linux distribution dependent (we plan on upgrading as part of [TOOL-7726](https://jira.delphix.com/browse/TOOL-7726)) and also requires setting apt keys and repository, a bit of a maintenance burden.

**Solution:**

Add the package. Test the change for this in conjunction with the change for TOOL-11707, which is being reviewed in [this appliance-build PR (ID 576)](https://github.com/delphix/appliance-build/pull/576).

**Testing:**

appliance-build-orchestrator-pre-push job: http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1078/console

See next comment: https://github.com/delphix/delphix-platform/pull/317#issuecomment-890221536

**Related tickets:**

- [TOOL-11707 PR](https://github.com/delphix/appliance-build/pull/576), adding Java 11 to `internal-dcenter` appliance-build
- [TOOL-11962](https://jira.delphix.com/browse/TOOL-11962): since `ca-certificates-java` is only being added to ESX and `internal-dcenter` will require this package, it makes sense to only build the `internal-dcenter` variant for ESX. This will also moderately decrease the number of appliance-build-stage1 post-push jobs from 42 (6 variants * 7 platforms) to 36 (5 variants * 7 platforms + 1 `internal-dcenter` for ESX)