### PR TITLE
DLPX-76840 delpix-platform is missing dmidecode which iscsi-name-init requires

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ DEPENDS += ansible, \
 	   cloud-init, \
 	   debootstrap, \
 	   debsums, \
+	   dmidecode, \
 	   net-tools, \
 	   open-iscsi, \
 	   openssh-server, \


### PR DESCRIPTION
# Description:
Change #300 introduced `iscsi-name-init.service` and the `get-system-uuid` command.  Since the `get-system-uuid` command requires `dmidecode(8)` it should be a required package for `delphix-platform`.

# Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5836/

Also, from a VM (cloned from the group created above) I verified that dmidecode was present and a dependency of `delphix-platform`.
```
delphix@ip-10-110-215-130:~$ apt-cache depends delphix-platform-aws | grep dmidecode
  Depends: dmidecode
```