### PR TITLE
DLPX-76870 [Backport of DLPX-76840 for 6.0.10.0]

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ DEPENDS += ansible, \
 	   cloud-init, \
 	   debootstrap, \
 	   debsums, \
+	   dmidecode, \
 	   net-tools, \
 	   open-iscsi, \
 	   openssh-server, \


### PR DESCRIPTION
# Description:
`delphix-platform` is missing `dmidecode` which `iscsi-name-init` service requires

Clean cherry pick of #319

# Testing
ab-pre-push:
   http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5856/