### PR TITLE
Revert "DLPX-76874 delphix-platform: add dependency on ntp (#321)"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -54,7 +54,6 @@ DEPENDS += ansible, \
 	   debsums, \
 	   dmidecode, \
 	   net-tools, \
-	   ntp, \
 	   open-iscsi, \
 	   openssh-server, \
 	   openssl, \


### PR DESCRIPTION
This reverts #321 as it causes DLPX-76954.

I think the issue is that now that we install ntp from delphix-platform instead of delphix-virtualization we also need to port the logic in preinst/postinst scripts that masks & disables ntp by default.
