### PR TITLE
DLPX-76874 delphix-platform: add dependency on ntp (re-integrate)

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -53,6 +53,33 @@ configure)
 	systemctl enable systemd-networkd.service
 	systemctl enable iscsi-name-init.service
 
+	#
+	# There's 3 types of services that we account for:
+	#
+	#  1. Services that are always enabled.
+	#  2. Services that are always disabled.
+	#  3. Services that are disabled by default, but may be
+	#     dynamically enabled.
+	#
+	# For more info, see comment in the preinst script.
+	#
+
+	#
+	# Here we account for services of type (3)
+	#
+	# The systemctl is-enabled will return false if the service is masked,
+	# disabled, or if the service doesn't exist yet. By checking this we will
+	# only unmask and disable the service if it wasn't already enabled.
+	#
+	while read -r svc; do
+		if ! systemctl is-enabled "$svc"; then
+			rm -f "/etc/systemd/system/$svc"
+			systemctl disable "$svc"
+		fi
+	done <<-EOF
+		ntp.service
+	EOF
+
 	if ! id -u postgres >/dev/null; then
 		# When installing postgres, a postgres user is created unless it
 		# already exists. To have a consistent UID accross installations

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,0 +1,54 @@
+#!/bin/bash -eux
+#
+# Copyright (c) 2021 by Delphix. All rights reserved.
+#
+
+#
+# Note that the logic below was copied from delphix-virtualization
+# to control whether or not some services should be started.
+#
+# There's 3 types of services that we account for:
+#
+#  1. Services that are always enabled.
+#  2. Services that are always disabled.
+#  3. Services that are disabled by default, but may be
+#     dynamically enabled.
+#
+# delphix-platform currently only needs to deal with services of type 3.
+#
+
+case $1 in
+install | upgrade)
+	#
+	# This is a bit of a hack, but we want to ensure these services
+	# don't start automatically when the package delivering that
+	# service is installed. Unfortunately there isn't a good way to
+	# disable services prior to the service being installed; at
+	# which point, the service might have already been started.
+	#
+	# Thus, we rely on this preinst hook to "mask" these services
+	# prior to the service being installed. Generally, we'll undo
+	# this hack in the postinst hook, by removing the symlink and
+	# simply disable the service using the "systemctl" command.
+	#
+
+	#
+	# Here we account for services of type (3)
+	#
+	# The systemctl is-enabled will return false if the service is masked,
+	# disabled, or if the service doesn't exist yet. By checking this we will
+	# only mask the service if it hasn't been installed, is disabled, or is
+	# already masked.
+	#
+	while read -r svc; do
+		if ! systemctl is-enabled "$svc"; then
+			ln -sf /dev/null "/etc/systemd/system/$svc"
+		fi
+	done <<-EOF
+		ntp.service
+	EOF
+
+	;;
+esac
+
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -54,6 +54,7 @@ DEPENDS += ansible, \
 	   debsums, \
 	   dmidecode, \
 	   net-tools, \
+	   ntp, \
 	   open-iscsi, \
 	   openssh-server, \
 	   openssl, \


### PR DESCRIPTION
This is a follow-up to #321 which was reverted in #322 because it caused DLPX-76954.

The problem with #321 was that previously ntp was installed by delphix-virtualization which took care of masking and disabling the service before it could run, but now that the installation of ntp was done before delphix-virtualiation's preinst/postinst scripts could run, the ntp service was never disabled.

This fix copies the logic from delphix-virtualization to deal with ntp.

One caveat with this new logic is that now on the `internal-dcenter` variant we would no longer run neither systemd-timesyncd nor ntp. Not sure how much of an issue that is though.

An alternative would be to not integrate this and to instead handle DLPX-76872 differently, however I think that having appliance-build first install systemd-timesyncd and then have it later replaced by ntp is not great.

A better approach in my opinion if we care about keeping the time on `internal-dcenter` syncrhonized would be to continue with this change, and then add additional code in the `internal-dcenter` ansible scripts to  re-enable ntp and set it up with some servers to sync-up with.

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5919/ (pass)