### PR TITLE
DLPX-77515 rpool should use lz4 compression

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -50,6 +50,7 @@ configure)
 	systemctl enable auditd.service
 	systemctl enable delphix.target
 	systemctl enable delphix-platform.service
+	systemctl enable delphix-rpool-upgrade.service
 	systemctl enable systemd-networkd.service
 	systemctl enable iscsi-name-init.service
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -27,6 +27,7 @@ upgrade | remove)
 
 	systemctl disable delphix.target
 	systemctl disable delphix-platform.service
+	systemctl disable delphix-rpool-upgrade.service
 
 	#
 	# We also need to remove the "ansible-done" file, to ensure that

--- a/files/common/lib/systemd/system/delphix-rpool-upgrade.service
+++ b/files/common/lib/systemd/system/delphix-rpool-upgrade.service
@@ -1,0 +1,29 @@
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[Unit]
+Description=Delphix "rpool" Upgrade Service
+ConditionVirtualization=!container
+PartOf=delphix.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/zpool upgrade rpool
+RemainAfterExit=yes
+
+[Install]
+WantedBy=delphix.target


### PR DESCRIPTION
`git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6149/)

I specifically chose not to put the `zpool upgrade` call in the existing `delphix-platform` service, to keep it from running inside of the upgrade verification container (and modifying the pool's format from within the container). As a result, the new pool format won't take affect until the first boot, since this means it also will not run at build-time, when building the initial VM disk images. I think that should be fine, and perhaps preferable, since the initial VM disk images are generated on an Ubuntu system, rather than a Delphix system, so the pool features available might be different.

One thing to note when upgrading the pool's on-disk format, is that we need to ensure that GRUB is compatible with all the features that we enable. I've verified that running `zpool upgrade rpool` works, in that I can boot from `rpool` after I do that, on a trunk-based system. It's unclear if this will continue to be the case, as new pool features are added. Still, I chose to use `zpool upgrade` here with the assumption that this won't be a practical problem for us, and the notion that it's likely better to use new features as soon as they become available; if this does become a problem, we should detect the issue during our testing cycle, and we could address it at that time.