### PR TITLE
DLPX-77577 nvme_core.io_timeout too small and causing problems in EC2

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -118,3 +118,11 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT init_on_alloc=0"
 # Disable the USB subsystem in its entirety for security reasons.
 #
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT usbcore.nousb=1"
+
+#
+# Set the NVME I/O timeout, effectively eliminating it, to align with
+# AWS recommendations. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
+# for details. Note that ZFS has its own built-in timeout mechanism, so we do not rely
+# on a separate I/O timeout mechanism for correctness at the storage device layer.
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT nvme_core.io_timeout=4294967295"


### PR DESCRIPTION
See the jira description for full details.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6192/flowGraphTable/

Manual testing:
```
root@ip-10-110-206-157:~# cat /proc/cmdline
BOOT_IMAGE=/ROOT/delphix.Rx4wf3d/root@/boot/vmlinuz-5.4.0-1056-dx2021091105-bbbb0e22c-aws root=ZFS=rpool/ROOT/delphix.Rx4wf3d/root ro console=tty0 console=ttyS0,38400n8 mitigations=off ipv6.disable=1 elevator=noop crashkernel=256M,high crashkernel=256M,low init_on_alloc=0 usbcore.nousb=1 nvme_core.io_timeout=4294967295
root@ip-10-110-206-157:~# cat /sys/module/nvme_core/parameters/io_timeout
4294967295
```