### PR TITLE
DLPX-77579 [Backport of DLPX-77577 to 6.0.11.0] nvme_core.io_timeout too small and causing problems in EC2

### DIFF
--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -118,3 +118,11 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT init_on_alloc=0"
 # Disable the USB subsystem in its entirety for security reasons.
 #
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT usbcore.nousb=1"
+
+#
+# Set the NVME I/O timeout, effectively eliminating it, to align with
+# AWS recommendations. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
+# for details. Note that ZFS has its own built-in timeout mechanism, so we do not rely
+# on a separate I/O timeout mechanism for correctness at the storage device layer.
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT nvme_core.io_timeout=4294967295"


### PR DESCRIPTION
Clean cherry-pick of #325