### PR TITLE
DLPX-75754 nfs-blkmap.service is running when it should be disabled

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2019 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -151,6 +151,13 @@
 # be flushed and lost prematurely.
 #
 - command: systemctl mask systemd-journald-audit.socket
+
+#
+# The nfs-blkmap.service is disabled by default but since it is wanted
+# by nfs-client.target it will always get started.  We don't use pNFS
+# so mask the nfs-blkmap.service to keep it from running.
+#
+- command: systemctl mask nfs-blkmap.service
 
 #
 # By default, the ulimit for core files is set to 0, and the default


### PR DESCRIPTION
# Description:
The `nfs-blkmap.service` is disabled by default but since it is wanted by `nfs-client.target` it is being started on the engine.  We don't use `pNFS` in the product so we now mask `nfs-blkmap.service` to keep it from being started.
# Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6279/

Manual Testing:
inspected an engine from the ab-pre-push image to confirm the service has been masked and is not running anymore:
```
delphix@ip-10-110-227-127:~$ sudo systemctl is-enabled nfs-blkmap.service
masked

delphix@ip-10-110-227-127:~$ sudo systemctl status nfs-blkmap.service
● nfs-blkmap.service
   Loaded: masked (/dev/null; bad)
   Active: inactive (dead)

delphix@ip-10-110-227-127:~$ sudo journalctl -u nfs-blkmap.service
-- Logs begin at Thu 2021-10-07 20:41:00 UTC, end at Thu 2021-10-07 20:48:32 UTC. --
-- No entries --
```