### PR TITLE
DLPX-75755 [Backport of DLPX-75754 to 6.0.11.0] nfs-blkmap.service is running when it should be disabled

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2019 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -151,6 +151,13 @@
 # be flushed and lost prematurely.
 #
 - command: systemctl mask systemd-journald-audit.socket
+
+#
+# The nfs-blkmap.service is disabled by default but since it is wanted
+# by nfs-client.target it will always get started.  We don't use pNFS
+# so mask the nfs-blkmap.service to keep it from running.
+#
+- command: systemctl mask nfs-blkmap.service
 
 #
 # By default, the ulimit for core files is set to 0, and the default


### PR DESCRIPTION
# Description:
The `nfs-blkmap.service` is disabled by default but since it is wanted by `nfs-client.target` it is being started on the engine.  We don't use `pNFS` in the product so we now mask `nfs-blkmap.service` to keep it from being started.

# Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6283/