### PR TITLE
DOSE-726 install rust-gdb on QA/customer images

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -119,6 +119,7 @@ DEPENDS += aptitude, \
 	   bpftrace, \
 	   bpftrace-dbgsym, \
 	   crash-python, \
+	   delphix-rust, \
 	   dnsutils, \
 	   drgn, \
 	   drgn-dbgsym, \


### PR DESCRIPTION
Note: I decided not to add this as a dependency of the ZFS package(s), since it's not required to use the ZFS binaries; we're only installing this package to get access to the debugging utility, `rust-gdb`, and we install other utilities in that category in the list modified here.