### PR TITLE
TOOL-12429 delphix-platform fails to build using latest ansible version

### DIFF
--- a/bootstrap/roles/delphix-platform.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/delphix-platform.bootstrap/tasks/main.yml
@@ -26,6 +26,8 @@
     - python3-docker
 
 - docker_image:
-    path: "{{ toplevel.stdout }}/docker"
+    build:
+      path: "{{ toplevel.stdout }}/docker"
     name: delphix-platform
-    force: true
+    source: build
+    force_source: true


### PR DESCRIPTION
This will allow us to keep building delphix-platform with the latest version of ansible provided by Ubuntu. See JIRA for more details.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6516/
- manually tested that this works by upgrading ansible on bootstrap image and then building delphix-platform on it.