### PR TITLE
DLPX-78306 [Backport of DLPX-76874 to 6.0.12.0] delphix-platform: add dependency on ntp

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -54,6 +54,7 @@ DEPENDS += ansible, \
 	   debsums, \
 	   dmidecode, \
 	   net-tools, \
+	   ntp, \
 	   open-iscsi, \
 	   openssh-server, \
 	   openssl, \


### PR DESCRIPTION
This essentially backports #323 and then also #333 which undoes a bunch of the complexity introduced in #323.

This will be pushed at the same time as the remaining work for DLPX-78304

## Testing
See https://github.com/delphix/appliance-build/pull/627