### PR TITLE
TOOL-12429 delphix-platform fails to build using latest ansible version

### DIFF
--- a/bootstrap/roles/delphix-platform.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/delphix-platform.bootstrap/tasks/main.yml
@@ -26,6 +26,8 @@
     - python3-docker
 
 - docker_image:
-    path: "{{ toplevel.stdout }}/docker"
+    build:
+      path: "{{ toplevel.stdout }}/docker"
     name: delphix-platform
-    force: true
+    source: build
+    force_source: true


### PR DESCRIPTION
Clean cherry-pick of #337 