### PR TITLE
TOOL-12474 Remove Jenkins job references to devops-gate/master in delphix-platform

### DIFF
--- a/files/common/usr/bin/download-latest-image
+++ b/files/common/usr/bin/download-latest-image
@@ -74,7 +74,7 @@ else
 fi
 
 aws s3 cp \
-	"s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/appliance-build/$opt_b/$build/latest" \
+	"s3://snapshot-de-images/builds/jenkins-ops/appliance-build/$opt_b/$build/latest" \
 	. || die "failed to download file: 'latest'"
 
 $opt_f && rm -f "$VARIANT.upgrade.tar" >/dev/null 2>&1


### PR DESCRIPTION
### Problem

As part of http://reviews.delphix.com/r/75405/ we are removing devops-gate/master from the
job hierarchy on Jenkins. Need to update all the references.

### Solution

Remove the references.

### Testing Done

Pending

### Deployment Plan
This needs to be merged after the new Jenkins controllers have been deployed. Otherwise, jobs would fail to fetch the right artifacts on S3 since the JOB_NAME will differ.
