### PR TITLE
TOOL-12547 [Backport of TOOL-12474 to 6.0/patch] Remove Jenkins job references to devops-gate/master in delphix-platform

### DIFF
--- a/files/common/usr/bin/download-latest-image
+++ b/files/common/usr/bin/download-latest-image
@@ -74,7 +74,7 @@ else
 fi
 
 aws s3 cp \
-	"s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/appliance-build/$opt_b/$build/latest" \
+	"s3://snapshot-de-images/builds/jenkins-ops/appliance-build/$opt_b/$build/latest" \
 	. || die "failed to download file: 'latest'"
 
 $opt_f && rm -f "$VARIANT.upgrade.tar" >/dev/null 2>&1


### PR DESCRIPTION
Clean cherrypick of: https://www.github.com/delphix/delphix-platform/pull/340