### PR TITLE
DLPX-77871 Need to install the usrmerge package on Ubuntu 20.04

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -110,6 +110,14 @@ DEPENDS += $(DEPENDS.$(TARGET_PLATFORM))
 DEPENDS += delphix-build-info,
 
 #
+# The usrmerge package modifies the layout of directories under root (/) upon
+# installation, to ensure that a Delphix Engine upgraded to Ubuntu 20.04 has
+# the same directory layout as a Delphix Engine that initially came on
+# Ubuntu 20.04 (or later).
+#
+DEPENDS += usrmerge,
+
+#
 # These packages are tools that are intended for human convenience. The
 # product should not rely on them programmatically. They may be updated
 # or replaced without regard for backward compatibility.


### PR DESCRIPTION
## Motivation:

This is needed so engines with Ubuntu 18.04 that are migrated to 20.04 have the exact same root filesystem structure/hierarchy as fresh install of 20.04.

## Testing:

ab-pre-push: TBA

Manual Testing TBA - upgrade an 18.04 VM with the upgrade image of the above link and ensure that the structure has indeed changed.

