### PR TITLE
DLPX-78307 Upgrade tests to trunk failed

### DIFF
--- a/files/common/lib/systemd/system/google-guest-agent.service.d/override.conf
+++ b/files/common/lib/systemd/system/google-guest-agent.service.d/override.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionVirtualization=!container


### PR DESCRIPTION
While reproducing this issue I see the following:
```
Dec  8 18:38:38 ps-78307-2 upgrade-scripts:upgrade-container[26167]: /var/dlpx-update/6.1.0.0-snapshot.20211208124616754+jenkins-ops-appliance-build-master-post-push-23/upgrade-container:do_upgrade_container_in_place:797 die ''\''systemctl restart delphix-platform'\'' failed in '\''delphix.IHYLP0V'\'''
Dec  8 18:38:38 ps-78307-2 upgrade-scripts:upgrade-container[26167]: //var/dlpx-update/6.1.0.0-snapshot.20211208124616754+jenkins-ops-appliance-build-master-post-push-23/common.sh:die:111 basename /var/dlpx-update/6.1.0.0-snapshot.20211208124616754+jenkins-ops-appliance-build-master-post-push-23/upgrade-container
Dec  8 18:38:38 ps-78307-2 upgrade-scripts:upgrade-container[26167]: /var/dlpx-update/6.1.0.0-snapshot.20211208124616754+jenkins-ops-appliance-build-master-post-push-23/common.sh:die:111 echo 'upgrade-container: '\''systemctl restart delphix-platform'\'' failed in '\''delphix.IHYLP0V'\'''
```
i.e. "delphix-platform" failed to restart..

```
Dec 08 18:38:38 ps-78307-2 apply[5373]: fatal: [localhost]: FAILED! => {
Dec 08 18:38:38 ps-78307-2 apply[5373]:     "changed": false,
Dec 08 18:38:38 ps-78307-2 apply[5373]:     "invocation": {
Dec 08 18:38:38 ps-78307-2 apply[5373]:         "module_args": {
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "daemon_reexec": false,
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "daemon_reload": false,
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "enabled": null,
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "force": null,
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "masked": null,
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "name": "google-guest-agent",
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "no_block": false,
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "scope": "system",
Dec 08 18:38:38 ps-78307-2 apply[5373]:             "state": "restarted"
Dec 08 18:38:38 ps-78307-2 apply[5373]:         }
Dec 08 18:38:38 ps-78307-2 apply[5373]:     },
Dec 08 18:38:38 ps-78307-2 apply[5373]:     "msg": "Unable to restart service google-guest-agent: Job for google-guest-agent.service failed because a timeout was exceeded.\nSee \"systemctl status google-guest-agent.service\" and \"journalctl -xe\" for details.\n"
Dec 08 18:38:38 ps-78307-2 apply[5373]: }
Dec 08 18:38:38 ps-78307-2 apply[5373]: META: ran handlers
Dec 08 18:38:38 ps-78307-2 apply[5373]: NO MORE HOSTS LEFT *************************************************************
Dec 08 18:38:38 ps-78307-2 apply[5373]: PLAY RECAP *********************************************************************
Dec 08 18:38:38 ps-78307-2 apply[5373]: localhost                  : ok=35   changed=11   unreachable=0    failed=1    skipped=4    rescued=0    ignored=0
Dec 08 18:38:38 ps-78307-2 apply[5360]: Failure when applying playbook.
Dec 08 18:38:38 ps-78307-2 systemd[1]: delphix-platform.service: Main process exited, code=exited, status=1/FAILURE
Dec 08 18:38:38 ps-78307-2 systemd[1]: delphix-platform.service: Failed with result 'exit-code'.
Dec 08 18:38:38 ps-78307-2 systemd[1]: Failed to start Delphix Appliance Platform Service.
```
i.e. "delphix-platform" failed to restart "google-guest-agent"

```
Dec 08 18:32:01 ps-78307-2 systemd[1]: Starting Google Compute Engine Guest Agent...
Dec 08 18:32:01 ps-78307-2 GCEGuestAgent[636]: 2021-12-08T18:32:01.8583Z GCEGuestAgent Error logger.go:75: Continuing without cloud logging due to error in initialization: google: could not find default credentials. See https://developer
s.google.com/accounts/docs/application-default-credentials for more information.
Dec 08 18:32:01 ps-78307-2 GCEGuestAgent[636]: 2021-12-08T18:32:01.8654Z GCEGuestAgent Info: GCE Agent Started (version 20210629.00-0ubuntu1~20.04.0)
Dec 08 18:32:02 ps-78307-2 GCEGuestAgent[636]: 2021-12-08T18:32:02.8550Z GCEGuestAgent Warning: Failed to set IO scheduler: open /sys/block/loop1/queue/scheduler: read-only file system
Dec 08 18:33:31 ps-78307-2 systemd[1]: google-guest-agent.service: start operation timed out. Terminating.
Dec 08 18:33:46 ps-78307-2 GCEGuestAgent[636]: 2021-12-08T18:33:46.4059Z GCEGuestAgent Critical main.go:294: error registering service: failed to shutdown within timeout 15s
Dec 08 18:33:46 ps-78307-2 systemd[1]: google-guest-agent.service: Main process exited, code=exited, status=1/FAILURE
Dec 08 18:33:46 ps-78307-2 systemd[1]: google-guest-agent.service: Failed with result 'timeout'.
Dec 08 18:33:46 ps-78307-2 systemd[1]: Failed to start Google Compute Engine Guest Agent.
Dec 08 18:33:46 ps-78307-2 systemd[1]: google-guest-agent.service: Scheduled restart job, restart counter is at 1.
Dec 08 18:33:46 ps-78307-2 systemd[1]: Stopped Google Compute Engine Guest Agent.
```
i.e. "google-guest-agent" failed..

So, while I'm not entirely sure why "google-guest-agent" failed, I don't think we care to run that service within the upgrade container to begin with.. so this change simply turns that service off, within the upgrade container.