### PR TITLE
DLPX-78449 [Backport of DLPX-78424 to 6.0.13.0] Increase ulimit for open files

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -174,6 +174,14 @@
     - '*'
 
 - lineinfile:
+    create: yes
+    path: /etc/security/limits.conf
+    line: "{{ item }} soft nofile 32768"
+  with_items:
+    - 'delphix'
+    - 'root'
+
+- lineinfile:
     path: /etc/ssh/sshd_config
     regexp: "^#?{{ item.key }} "
     line: "{{ item.key }} {{ item.value }}"


### PR DESCRIPTION
### Context:
This pull request attempts to increase the soft limit for "number of open file descriptors" for the users "delphix" and "root" on our engine.

### Problem:
The performance team encountered "out of file descriptors" errors on some of their test cases in the fio test suite. The fio suite itself has a bug which leads to leaked file descriptors during the test runs.

### Solution:
We are increasing the soft limit for "open file descriptors" from the current value of 1024 to 32768. This value was decided during consultations with the performance team. Since we do not see any reason for users other than "delphix" and "root" ever running into this problem, we want to keep the change limited to the affected users only. We are thus going for the minimum set of changes that are needed to fix this problem.
The hard limit is kept unchanged from its current value of 1048576 because we do not expect to hit this limit in any scenario in the near future.

### Testing:
1. ab-pre-push results -- http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/345

### Implementation:
The fix is implemented by adding the relevant lines via ansible playbook in /etc/security/limits.conf.

### Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.

### Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.

### Future work:
NA

### Bonus:
NA
