### PR TITLE
DLPX-79034 systemd-networkd releases its DHCP lease on restart

### DIFF
--- a/files/common/lib/systemd/network/99-delphix-defaults.network
+++ b/files/common/lib/systemd/network/99-delphix-defaults.network
@@ -1,0 +1,17 @@
+#
+# See systemd.network(5) for a description of KeepConfiguration. We make this
+# change here because the default behavior of systemd-networkd starting in
+# Ubuntu 20.04 is to release a DHCP lease upon stopping systemd-networkd (even
+# in the context of a restart). The impact of this is that the system's
+# default route and IP address are removed, and then added back again when the
+# service is started back up, resulting in a brief loss of network
+# connectivity. Delphix, being a critical piece of infrastructure, cannot
+# afford brief loss of connectivity. We thus change the KeepConfiguration
+# setting so that systemd-networkd does not release the lease on stop.
+#
+
+[Match]
+Name=*
+
+[Network]
+KeepConfiguration=dhcp-on-stop


### PR DESCRIPTION
This PR addresses an issue that was introduced with the new version of systemd-networkd in Ubuntu 20.04, which is that when systemd-networkd stops (which happens when it restarts as part of applying an updated network configuration, for example), it releases its DHCP lease. A new lease is acquired when systemd-networkd starts again, but this leaves a window where the system has no IP address nor routes (those that were tied to the DHCP lease).

The fix is to configure systemd-networkd not to drop the lease on stop. A lease can be explicitly dropped by deleting a DHCP address (the only time when a lease should be dropped...).

This bug was responsible for the multitudes of dx-test failures documented in https://delphix.atlassian.net/browse/TOOL-12800, and there's a comment in that bug describing the RCA that lead to this bug fix.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/695/