### PR TITLE
DLPX-80287 remove unnecessary "recommended" packages from appliance

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -50,9 +50,11 @@ DEPENDS += grub-pc, \
 DEPENDS += ansible, \
 	   auditd, \
 	   cloud-init, \
+	   cron, \
 	   debootstrap, \
 	   debsums, \
 	   dmidecode, \
+	   logrotate, \
 	   net-tools, \
 	   ntp, \
 	   open-iscsi, \


### PR DESCRIPTION
We don't have any explicit package dependencies on these two packages, yet the product depends on them; this change makes this dependency explicit. This required before landing https://github.com/delphix/appliance-build/pull/665.