### PR TITLE
DLPX-80427 zcache crashes after a deferred upgrade

### DIFF
--- a/files/common/lib/systemd/system/zfs-object-agent.service.d/override.conf
+++ b/files/common/lib/systemd/system/zfs-object-agent.service.d/override.conf
@@ -1,0 +1,21 @@
+#
+# Copyright 2022 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[Unit]
+PartOf=delphix.target
+
+[Install]
+WantedBy=delphix.target


### PR DESCRIPTION
This overrides our `zfs-object-agent` systemd service so that it's included as part of `delphix.target`.