### PR TITLE
DLPX-80598 [Backport of DLPX-80427 to 6.0.14.0] zcache crashes after a deferred upgrade

### DIFF
--- a/files/common/lib/systemd/system/zfs-object-agent.service.d/override.conf
+++ b/files/common/lib/systemd/system/zfs-object-agent.service.d/override.conf
@@ -1,0 +1,21 @@
+#
+# Copyright 2022 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[Unit]
+PartOf=delphix.target
+
+[Install]
+WantedBy=delphix.target


### PR DESCRIPTION
This adds an override.conf file to the zfs-object-agent.service. We add
this to delphix-platform since this is where we do any zfs customizations
which are delphix-specific.
