### PR TITLE
DLPX-80424 [Backport of DLPX-80287 to 6.0.14.0] remove unnecessary "recommended" packages from appliance

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -50,9 +50,11 @@ DEPENDS += grub-pc, \
 DEPENDS += ansible, \
 	   auditd, \
 	   cloud-init, \
+	   cron, \
 	   debootstrap, \
 	   debsums, \
 	   dmidecode, \
+	   logrotate, \
 	   net-tools, \
 	   ntp, \
 	   open-iscsi, \


### PR DESCRIPTION
Clean cherry-pick of #364 