### PR TITLE
DLPX-80765 [Backport of DLPX-80760 to 6.0.15.0] default value for "fs…

### DIFF
--- a/files/common/lib/sysctl.d/50-override.conf
+++ b/files/common/lib/sysctl.d/50-override.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2022 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,3 +87,9 @@ vm.overcommit_memory = 1
 # mounts allowed by the system must be 3 times the supported value.
 #
 fs.mount-max = 300000
+
+#
+# We've seen cases where we run out of this resource with the default
+# value of 8192, resulting in upgrade failures.
+#
+fs.inotify.max_user_watches = 16384


### PR DESCRIPTION
….inotify.max_user_watches" is insufficient in some cases