### PR TITLE
DLPX-81584 Remove aging and weak sshd message code algorithms

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
@@ -25,3 +25,9 @@
     state: restarted
   listen: "gcp config changed"
   when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot
+
+- systemd:
+    name: sshd
+    state: reloaded
+  listen: "sshd config changed"
+  when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -258,6 +258,38 @@
     replace: '#\1'
 
 #
+# Prevent sshd from offering weak message authentication codes to clients.
+#
+# The "MACs" configuration parameter in sshd_config takes a list of algorithms
+# as its parameter. This list may be prefixed by a '+' or '-' operator
+# (indicating that the given list should be appended to or removed from the
+# existing MAC set, respectively), or neither operator (indicating that the
+# given list should replace the existing MAC set). If there already exists a
+# "MACs -..."  line, we can append to this list. If otherwise, we need to add
+# this as a separate line in the configuration.
+#
+- shell: grep -c -E "^MACs(\s+)-" /etc/ssh/sshd_config || true
+  register: grep_sshd_config_macs_to_remove
+
+- shell: grep -c -E "^MACs(\s+)-(.*)hmac-sha1\*,umac-64\*" /etc/ssh/sshd_config || true
+  register: grep_sshd_config_macs_already_removed
+
+- lineinfile:
+    path: /etc/ssh/sshd_config
+    backrefs: yes
+    regexp: '^MACs[\s]+-(.*)$'
+    line: 'MACs -\1,hmac-sha1*,umac-64*'
+  notify: "sshd config changed"
+  when: grep_sshd_config_macs_to_remove.stdout != "0" and grep_sshd_config_macs_already_removed == "0"
+
+- lineinfile:
+    path: /etc/ssh/sshd_config
+    insertafter: EOF
+    line: "MACs -hmac-sha1*,umac-64*"
+  notify: "sshd config changed"
+  when: grep_sshd_config_macs_to_remove.stdout == "0"
+
+#
 # Enable SNMP client tools to load MIBs by default.
 #
 - replace:


### PR DESCRIPTION
### Problem

Multiple customers have reported that their security scanners are
flagging that the SSH server used on the Delphix engine offers
`hmac-sha1` and `umac-64` message authentication codes, which are
considered cryptographically weak.

### Evaluation

We are not specifying a MAC configuration in our `sshd_config`,
and the relevant MACs are still included by default as of Ubuntu
20.04.

### Solution

Modify the delphix-platform ansible script to insert a configuration
which removes all hmac-sha1 and umac-64 MACs from the set of enabled
MACs.

### Testing Done

~~NONE -- Preliminary review. The configuration change in question has
been tested manually on an engine but I have not tested using the
ansible change to apply this configuration.~~ See [below](https://github.com/delphix/delphix-platform/pull/379#issuecomment-1159213452
)