### PR TITLE
DOSE-1219 Add Azure CLI to Delphix Engine

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -97,7 +97,7 @@ DEPENDS += pam-challenge-response, \
 
 # Platform-specific dependencies
 DEPENDS.aws = nvme-cli,
-DEPENDS.azure = walinuxagent,
+DEPENDS.azure = walinuxagent, azure-cli,
 DEPENDS.esx = open-vm-tools,
 DEPENDS.gcp = google-compute-engine, google-guest-agent,
 DEPENDS.hyperv =


### PR DESCRIPTION
This PR adds the Azure CLI to our VMs. Thankfully, Ubuntu ships an azure-cli package that Azure doesn't list in their official installation instructions; this reduced the difficulty of adding the utilities to the image. The package is added to the azure dependencies; this means it will not be installed on normal dcenter VMs. This is a slightly drawback of this approach, but it is easy enough to install in that case. It also means the package would not be installed on ESX VMs that customers have on-prem, but using those to talk to azure blob storage doesn't seem like an important use case.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/2208/ in progress