### PR TITLE
DLPX-77850 Bump zvol threads count from 32 to 256

### DIFF
--- a/files/common/lib/modprobe.d/10-zfs.conf
+++ b/files/common/lib/modprobe.d/10-zfs.conf
@@ -97,3 +97,10 @@ options zfs zfs_override_estimate_recordsize=8192
 # which is what we used in illumos.
 #
 options zfs zfs_arc_meta_strategy=0
+
+#
+# Increasing zvol taskq threads to 256 to improve performance for some
+# workloads. Taskq threads are created and destroyed dynamically so there
+# should be minimal to no impact on small systems.
+#
+options zfs zvol_threads=256


### PR DESCRIPTION
# Context/Problem:
Default 32 zvol taskq threads can be a bottleneck in some workloads. We've seen this problem at some customers.

# Solution:
Setting zvol_threads tunable to 256 to improve performance. Taskq threads are created and destroyed dynamically so there should be minimal to no impact on small systems.

A hotfix with the change has been running at customer for a few months without any issue.

# Testing
Functional - Ran git-ab-pre-push then verified engine cloned from the resulting image have the correct settings.

```
tnguyen@dlpxdc:~$ dc groups list | grep nguyen
dlpx-tnguyen-master                            2022-08-17-17-41  Delphix Engine trunk  2177 1ecb3442
tnguyen@dlpxdc:~$
tnguyen@dlpxdc:~$
tnguyen@dlpxdc:~$ date
Wed Aug 17 22:40:18 UTC 2022
tnguyen@dlpxdc:~$ dc clone-latest dlpx-tnguyen-master tnguyen-master-77850
tnguyen-master-77850 - dlpx-tnguyen-master
.....
delphix@ip-10-110-245-243:~$ grep zvol_thread /lib/modprobe.d/10-zfs.conf
options zfs zvol_threads=256
delphix@ip-10-110-245-243:~$ egrep "^taskq|^zvol" /proc/spl/taskq-all
taskq                       act  nthr  spwn  maxt   pri  mina         maxa  cura      flags
zvol/0                        0    82     0   256   100   256   2147483647   256   80000005
delphix@ip-10-110-245-243:~$
```

Performance testing shows:
1) there’s performance improvement with 256 zvol_thread 
2) And no negative impact even on smaller (recommended) configuration of 8 vCPUs and 128 GB of memory

Results with 4 SSD disks:
4disks.20cpus
===========  Default zvol_threads=32 =========
read: 2500 MB/s , zvol lat ~3ms, iscsi lat ~10ms
write: 1000 - 1100 MB/s, zvol lat 7ms, iscsi lat ~25ms
=========== zvol_threads=256 ==============
read: 2800 - 2900 MB/s, zvol lat 5ms, iscsi lat 8ms
write: 1000 - 1100 MB/s, zvol lat 8ms, iscsi lat ~19ms

4disks.24cpus
=============  Default zvol_threads=32 ========
read: 2900 MB/s, zvol lat 2.6ms, iscsi lat 8.2ms
write: 1100 MB/s, zvol lat 5.5ms, iscsi lat ~20ms
============= zvol_threads=256 ==============
read: 2800 - 3100 MB/s, zvol lat ~6ms, iscsi lat ~7ms
write: 1050-1200 MB/s, zvol lat ~7ms, iscsi lat ~18ms

4disks.8cpus
================ Default zvol_threads=32 =====
read: 1500 - 1570 MB/s, zvol lat 4.9ms, iscsi lat 16.7ms
write: 650-720 MB/s, zvol lat 5.3ms, iscsi lat ~29ms
================ zvol_threads=256 ===========
read: 1500 - 1600 MB/s, zvol lat ~13ms, iscsi lat ~16ms
write: 680 - 750 MB/s, zvol lat 5.5ms, iscsi lat ~25ms

Results with 8 SSD disks:
8disks.20cpus
=============  Default zvol_threads=32 ========
read: 2700 MB/s, zvol lat 2.7ms, iscsi lat 8.3ms
write: ~1150 MB/s, zvol lat 2.9ms, iscsi lat 16.7ms
============= zvol_threads=256 =============
read: 2800 MB/s, zvol lat 5.6ms, iscsi lat 7.6ms
write: 1100 MB/s, zvol lat 3.1ms, iscsi lat 16.9ms

8disks.24cpus
============  Default zvol_threads=32 ==========
read: 2800-2900 MB/s, zvol lat 2.7ms, iscsi lat 8.6ms
write: 1050-1100 MB/s, zvol lat 4.5ms, iscsi lat 20.5ms
============ zvol_threads=256 ===============
read: 2900-3000 MB/s, zvol lat 5.5ms, iscsi lat 7ms
write: 1100-1200 MB/s, zvol lat ~4ms, iscsi lat 15.8ms

Test configuration
Engine (perfkit3 ESX) - 20 vCPUs , 256 GB memory, 4 x 50 disks, 30 Gbps network
Target(s) - 2 x Windows target (8 vCPUs and 24 GB memory)

<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
