### PR TITLE
DLPX-83141 Network interface alias name doesn't persist post upgrade(6.0.14.0 -> 6.0/stage)

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -101,6 +101,7 @@ configure)
 		# Any future changes in the line we are updating must be detected and investigated and rule should be updated accordingly.
 		# To accomplish this strict checking, we pass the entire line as an argument to the sed command, which should fail at the
 		# slightest change in the contents of the line.
+		# shellcheck disable=SC2016
 		sed -i 's/NAME=="", ENV{ID_NET_NAME}!="", NAME="$env{ID_NET_NAME}"/NAME=="", ENV{ID_NET_NAME_MAC}!="", NAME="$env{ID_NET_NAME_MAC}"/' \
 			"$MODIFIED_UDEV_NET_SETUP_LINK_DIR"/80-net-setup-link.rules
 

--- a/files/aws/usr/bin/update_netplan_to_mac_address
+++ b/files/aws/usr/bin/update_netplan_to_mac_address
@@ -15,6 +15,7 @@
 INTERFACE_TO_MACADDRESS_MAP_FILE="/etc/interface_to_macaddress_map.out"
 DLPX_NETPLAN_DIR="/etc/netplan/"
 DLPX_NETPLAN_NAME="10-delphix.yaml"
+DLPX_INTERFACE_NAMES_YAML="/etc/delphix-interface-names.yaml"
 SYSFS_NET_DIRECTORY="/sys/class/net"
 
 function die() {
@@ -46,6 +47,11 @@ if [[ -e "$INTERFACE_TO_MACADDRESS_MAP_FILE" ]] &&
 			echo "Modifying $ifname to $macname in the netplan file"
 			sed -i "s/$ifname/$macname/g" "$DLPX_NETPLAN_DIR""$DLPX_NETPLAN_NAME" ||
 				die "Could not modify $ifname to $macname in the netplan file"
+		fi
+		if grep -q "$ifname:" "$DLPX_INTERFACE_NAMES_YAML"; then
+			echo "Modifying $ifname to $macname in the $DLPX_INTERFACE_NAMES_YAML file"
+			sed -i "s/$ifname/$macname/" "$DLPX_INTERFACE_NAMES_YAML" ||
+				die "Could not modify $ifname to $macname in the $DLPX_INTERFACE_NAMES_YAML file"
 		fi
 	done <"$INTERFACE_TO_MACADDRESS_MAP_FILE"
 	echo "Updated all the interface names to mac address based names"


### PR DESCRIPTION
# Context:
[DLPX-75209](https://github.com/delphix/delphix-platform/pull/385) provided for mac address based network interface names in AWS only environments. It however missed out on updating the `/etc/delphix-interface-names.yaml` file stores a map of interface names and their alias names that can be customized by the end users.

# Problem:
Any existing alias names in the file `/etc/delphix-interface-names.yaml` should be retained after upgrading to mac based interface names. The fix for DLPX-75209 missed out on updating this file post upgrade.

# Solution:
We leverage the `/usr/bin/update_netplan_to_mac_address` script to update the `/etc/delphix-interface-names.yaml` during the same time we are updating the interface names in `/etc/netplan/10-delphix.yaml file`.

# Testing
ab-pre-push run in progress -- http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/3417/flowGraphTable/

Tested manually by first creating alias names on 6.0.16.0, and then checked if the alias names are retained or not after upgrading to 6.0.17.0.

Contents of the file /etc/delphix-interface-names.yaml before upgrade, on 6.0.16.0 --
delphix@ip-10-110-241-55:/var/dlpx-update/upload$ cat /etc/delphix-interface-names.yaml 
```
---
DelphixNetworkInterfaceNames:
  aliases:
    ens5: "custom-ens5"
    ens6: "custom-ens6"
```
   
Contents of the file /etc/delphix-interface-names.yaml post upgrade to 6.0.17.0 which contains the fix --
delphix@ip-10-110-241-55:~$ cat /etc/delphix-interface-names.yaml
```
---
DelphixNetworkInterfaceNames:
  aliases:
    enx020dc71194f1: "custom-ens5"
    enx02bbbec373bd: "custom-ens6"
```

# Implementation:
We leverage the `/usr/bin/update_netplan_to_mac_address` script to update the `/etc/delphix-interface-names.yaml` during the same time we are updating the interface names in `/etc/netplan/10-delphix.yaml file`.

# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
