### PR TITLE
DLPX-83611 Increase zfs_vdev_open_timeout_ms to workaround dev link races during import

### DIFF
--- a/files/common/lib/modprobe.d/10-zfs.conf
+++ b/files/common/lib/modprobe.d/10-zfs.conf
@@ -104,3 +104,14 @@ options zfs zfs_arc_meta_strategy=0
 # should be minimal to no impact on small systems.
 #
 options zfs zvol_threads=256
+
+#
+# Wait up to 3 minutes for device to show up during import. We do this to
+# account for occasional races between our ZFS pool import service
+# (zfs-import-cache.service) and udev-related services where the ZFS cache file
+# references device symbolic links in the by-id directory that haven't been
+# created yet by udevd. These races generally occur with a time difference of
+# ~100ms but if the device itself is experiencing I/O errors the delay in the
+# link creation can get up to the order of a minute or more.
+#
+options zfs zfs_vdev_open_timeout_ms=180000


### PR DESCRIPTION
ab-pre-push link: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/3703/

Manual Testing:
Cloned a VM from the above ab-pre-push snapshot and verified that the tunable was correctly set:
```
sdimitropoulos@dlpxdc:~$ dc clone-latest  dlpx-sdimitropoulos-6.0/stage sd-timeout
sd-timeout - dlpx-sdimitropoulos-6.0/stage
...
$ ssh sd-timeout.dlpxdc.co
delphix@ip-10-110-202-109:~$ ls
delphix@ip-10-110-202-109:~$ sudo cat /sys/module/zfs/parameters/zfs_vdev_open_timeout_ms
180000
```

This change depends on https://github.com/openzfs/zfs/pull/14133