### PR TITLE
CP-9284 relocate var/dephix for a brand new delphix engine

### DIFF
--- a/files/common/lib/systemd/system/delphix-platform.service
+++ b/files/common/lib/systemd/system/delphix-platform.service
@@ -24,6 +24,7 @@ Before=rsync.service docker.service
 Type=oneshot
 ExecStart=/var/lib/delphix-platform/ansible/apply
 ExecStart=/var/lib/delphix-platform/dynamic-debug
+ExecStart=/var/lib/delphix-platform/relocate-var-delphix
 RemainAfterExit=yes
 
 #

--- a/files/common/var/lib/delphix-platform/relocate-var-delphix
+++ b/files/common/var/lib/delphix-platform/relocate-var-delphix
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# Copyright (c) 2022, 2022 by Delphix. All rights reserved.
+#
+
+VAR_DELPHIX_MOUNTPOINT="/var/delphix"
+VAR_DELPHIX_MOUNTPOINT_TMP="/var/delphix-relocation-tmp"
+
+# domain0 shall have enough free space before relocating /var/delphix: 1GB (threshold) + "size of /var/delphix" free space
+# TODO: find a proper value
+SPACE_THRESHOLD_IN_BYTES=1000000000
+
+die()
+{
+	echo "$(basename $0): $*" >&2
+	exit 1
+}
+
+#
+# This function will return mounted filesystem of /var/delphix
+# for example:
+# - before relocation, it returns "rpool/ROOT/delphix.pY64Vhq/data"
+# - after relocation, it returns "domain0/delphix.pY64Vhq/data"
+#
+function get_mounted_var_delphix_dataset() {
+	zfs list -Hpo name $VAR_DELPHIX_MOUNTPOINT
+}
+
+#
+# This function will return container name (i.e. "delphix.xxxxxxx") of /var/delphix dataset
+# for example, if the dataset is "rpool/ROOT/delphix.pY64Vhq/data", it returns delphix.pY64Vhq
+#
+function get_mounted_container_name() {
+	basename "$(dirname $(get_mounted_var_delphix_dataset))"
+}
+
+function get_available_space_in_domain0() {
+	zfs list -Hpo available domain0
+}
+
+function get_dataset_used_space() {
+	[[ -n "$1" ]] || die "failed to provide dataset"
+	local DATASET_NAME="$1"
+	zfs list -Hpo used $DATASET_NAME
+}
+
+function relocate_var_delphix() {
+	#
+	# if domain0 is not existing, that means the engine has not initialized yet, no need to relocate
+	#
+	if ! zpool list domain0 &>/dev/null; then
+		echo "engine is not initialized yet, skip relocating $VAR_DELPHIX_MOUNTPOINT"
+		return
+	fi
+
+	MOUNTED_CONTAINER=$(get_mounted_container_name)
+	VAR_DELPHIX_FS_MOUNTED=$(get_mounted_var_delphix_dataset)
+	echo "got current mounted filesystem of $VAR_DELPHIX_MOUNTPOINT: $VAR_DELPHIX_FS_MOUNTED"
+
+	#
+	# if /var/delphix has already mounted to domain0, no need to relocate it again.
+	#
+	if [[ $VAR_DELPHIX_FS_MOUNTED == "domain0/delphix"* ]]; then
+		echo "$VAR_DELPHIX_MOUNTPOINT has already been in domain0, skip relocating"
+		return
+	fi
+
+	#
+	# check if there is enough space in domain0
+	#
+	VAR_DELPHIX_USED_SPACE=$(get_dataset_used_space $VAR_DELPHIX_FS_MOUNTED)
+	VAR_DELPHIX_REQUIRED_SPACE=$(expr $VAR_DELPHIX_USED_SPACE + $SPACE_THRESHOLD_IN_BYTES)
+	DOMAIN0_AVILABLE_SPACE=$(get_available_space_in_domain0)
+
+	if (( "$DOMAIN0_AVILABLE_SPACE" < "$VAR_DELPHIX_REQUIRED_SPACE")); then
+		die "no enough space to relocate /var/delphix, required at least $VAR_DELPHIX_REQUIRED_SPACE bytes," \
+			"but only $DOMAIN0_AVILABLE_SPACE bytes available"
+	fi
+
+	#
+	# start relocating /var/delphix
+	#
+	VAR_DELPHIX_PARENT_FS="domain0/$MOUNTED_CONTAINER"
+	VAR_DELPHIX_FS_OLD=$VAR_DELPHIX_FS_MOUNTED
+	VAR_DELPHIX_FS_NEW="$VAR_DELPHIX_PARENT_FS/data"
+	echo "start relocating $VAR_DELPHIX_MOUNTPOINT from $VAR_DELPHIX_FS_OLD to $VAR_DELPHIX_FS_NEW"
+
+	#
+	# create parent filesystem domain0/delphix.xxxxxxx
+	#
+	echo "creating parent file system $VAR_DELPHIX_PARENT_FS"
+	zfs create -o canmount=off -o mountpoint=none $VAR_DELPHIX_PARENT_FS ||
+		die "creating parent file system $VAR_DELPHIX_PARENT_FS failed"
+
+	#
+	# create filesystem domain0/delphix.xxxxxxx/data and mount it to temp folder
+	# TODO: set up properties of filesystem, upgrade will need that info
+	echo "creating filesystem $VAR_DELPHIX_FS_NEW and mounting it to temp mountpoint $VAR_DELPHIX_MOUNTPOINT_TMP"
+	zfs create -o mountpoint=$VAR_DELPHIX_MOUNTPOINT_TMP $VAR_DELPHIX_FS_NEW ||
+		die "creating data filesystem $VAR_DELPHIX_FS_NEW failed"
+
+	#
+	# copy files from /var/delphix to temp folder
+	#
+	## TODO: find most suitable flag of rsync
+	echo "copying files from $VAR_DELPHIX_MOUNTPOINT to $VAR_DELPHIX_MOUNTPOINT_TMP"
+	rsync -aAx $VAR_DELPHIX_MOUNTPOINT/* $VAR_DELPHIX_MOUNTPOINT_TMP ||
+		die "copying files from $VAR_DELPHIX_MOUNTPOINT to $VAR_DELPHIX_MOUNTPOINT_TMP failed"
+
+	#
+	# clean up /var/delphix mount record in /etc/fstab, this shall be done before destroying filesystem $VAR_DELPHIX_FS_OLD
+	#
+	echo "cleaning up mount record of /var/delphix in /etc/fstab"
+	sed -i "/\/var\/delphix/d" /etc/fstab ||
+		die "removing mount record of /var/delphix from /ect/fstab failed"
+
+	#
+	# clean old filesystem in rpool to save space
+	# TODO: what if it fails to destroy? for instance, after a failed upgrade - verification?
+	# TODO: destroy will fail with error "dataset is busy" for the first time, but if destroy again, it will succeed.
+	# TODO: based on experiments, it seems destroying filesystem will umount /var/delphix from domain0 as well??? since mountpoint=legacy
+	# TODO: double confirm the space has been freed up
+	LEGACY_FS_TO_DELETE="rpool/ROOT/${MOUNTED_CONTAINER}/data"
+	if [[ $VAR_DELPHIX_FS_OLD == $LEGACY_FS_TO_DELETE ]]; then
+  		echo "destroying legacy filesystem $VAR_DELPHIX_FS_OLD to save space"
+      zfs destroy $VAR_DELPHIX_FS_OLD ||
+      	echo "warning: destroying legacy filesystem $VAR_DELPHIX_FS_OLD failed, please manually clean it"
+  else
+  		# when developer_reset the engine, the /var/delphix will mount to rpool/ROOT/delphix.xxxxxxx/root,
+  		# we can't destroy legacy filesystem in this case
+  		echo "warning: legacy filesystem not expected, expected $LEGACY_FS_TO_DELETE but got $VAR_DELPHIX_FS_OLD, skipped"
+  fi
+
+	#
+	# change mountpoint from temp folder to official folder
+	# since destroy legacy filesystem will umount /var/delphix, so we put setting mointpoint as last step
+	#
+	echo "mounting $VAR_DELPHIX_FS_NEW to $VAR_DELPHIX_MOUNTPOINT"
+	zfs set mountpoint=$VAR_DELPHIX_MOUNTPOINT $VAR_DELPHIX_FS_NEW ||
+		die "change mountpoint of $VAR_DELPHIX_FS_NEW to $VAR_DELPHIX_MOUNTPOINT failed"
+
+	#
+	# clean up temp folder
+	#
+	rm -rf $VAR_DELPHIX_MOUNTPOINT_TMP ||
+		die "cleaning up $VAR_DELPHIX_MOUNTPOINT_TMP failed"
+
+	echo "successfully relocated $VAR_DELPHIX_MOUNTPOINT from $VAR_DELPHIX_FS_OLD to $VAR_DELPHIX_FS_NEW"
+}
+
+relocate_var_delphix


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
TBD

# Solution:
Still working in progress

# Testing

## before relocation
```
$ zfs list
NAME                              USED  AVAIL  REFER  MOUNTPOINT
domain0                          2.00G  19.8G    24K  /domain0
domain0/group-2                    24K  19.8G    24K  /domain0/group-2
domain0/mds                        24K  21.8G    24K  /mds
rpool                            15.1G  52.3G    65K  none
rpool/ROOT                       15.1G  52.3G    65K  none
rpool/ROOT/delphix.MpOla39       15.1G  52.3G    64K  none
rpool/ROOT/delphix.MpOla39/data  41.6M  52.3G  41.6M  legacy
rpool/ROOT/delphix.MpOla39/home  6.60G  52.3G  6.60G  legacy
rpool/ROOT/delphix.MpOla39/log   24.9M  52.3G  24.9M  legacy
rpool/ROOT/delphix.MpOla39/root  8.41G  52.3G  8.41G  /
rpool/crashdump                  28.5K  34.7G  28.5K  legacy
rpool/docker                      314K  52.3G   314K  -
rpool/grub                       3.08M  52.3G  3.08M  legacy
rpool/public                       29K  52.3G    29K  /public
rpool/update                       30K  30.0G    30K  /var/dlpx-update
rpool/upgrade-logs                 29K  52.3G    29K  /var/tmp/delphix-upgrade
```

## after relocation
```
$ zfs list
NAME                              USED  AVAIL  REFER  MOUNTPOINT
domain0                          2.01G  19.8G    24K  /domain0
domain0/delphix.MpOla39          7.37M  19.8G    24K  none
domain0/delphix.MpOla39/data     7.34M  19.8G  7.34M  /var/delphix
domain0/group-2                    24K  19.8G    24K  /domain0/group-2
domain0/mds                      46.7M  21.7G  46.7M  /mds
rpool                            14.8G  52.5G    65K  none
rpool/ROOT                       14.8G  52.5G    65K  none
rpool/ROOT/delphix.MpOla39       14.8G  52.5G    64K  none
rpool/ROOT/delphix.MpOla39/home  6.60G  52.5G  6.60G  legacy
rpool/ROOT/delphix.MpOla39/log   25.9M  52.5G  25.9M  legacy
rpool/ROOT/delphix.MpOla39/root  8.18G  52.5G  8.18G  /
rpool/crashdump                  28.5K  34.7G  28.5K  legacy
rpool/docker                      330K  52.5G   330K  -
rpool/grub                       3.08M  52.5G  3.08M  legacy
rpool/public                       29K  52.5G    29K  /public
rpool/update                       30K  30.0G    30K  /var/dlpx-update
rpool/upgrade-logs                 29K  52.5G    29K  /var/tmp/delphix-upgrade

$ cat /etc/fstab
rpool/ROOT/delphix.MpOla39/home /export/home zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
rpool/ROOT/delphix.MpOla39/log  /var/log     zfs defaults,x-systemd.before=zfs-import-cache.service 0 0
rpool/crashdump  /var/crash     zfs defaults,x-systemd.before=zfs-import-cache.service,x-systemd.before=kdump-tools.service 0 0
```

logs
```
Nov 03 04:22:01 ip-10-110-218-78 relocate-var-delphix[30120]: got current mounted filesystem of /var/delphix: rpool/ROOT/delphix.MpOla39/data
Nov 03 04:22:01 ip-10-110-218-78 relocate-var-delphix[30120]: start relocating /var/delphix from rpool/ROOT/delphix.MpOla39/data to domain0/delphix.MpOla39/data
Nov 03 04:22:01 ip-10-110-218-78 relocate-var-delphix[30120]: creating parent file system domain0/delphix.MpOla39
Nov 03 04:22:01 ip-10-110-218-78 relocate-var-delphix[30120]: creating filesystem domain0/delphix.MpOla39/data and mounting it to temp mountpoint /var/delphix-relocation-tmp
Nov 03 04:22:01 ip-10-110-218-78 relocate-var-delphix[30120]: copying files from /var/delphix to /var/delphix-relocation-tmp
Nov 03 04:22:03 ip-10-110-218-78 relocate-var-delphix[30120]: cleaning up mount record of /var/delphix in /etc/fstab
Nov 03 04:22:03 ip-10-110-218-78 relocate-var-delphix[30120]: destroying legacy filesystem rpool/ROOT/delphix.MpOla39/data to save space
Nov 03 04:22:03 ip-10-110-218-78 relocate-var-delphix[30120]: mounting domain0/delphix.MpOla39/data to /var/delphix
Nov 03 04:22:03 ip-10-110-218-78 relocate-var-delphix[30120]: successfully relocated /var/delphix from rpool/ROOT/delphix.MpOla39/data to domain0/delphix.MpOla39/data
```
## test with developer_reset
### after developer_reset the engine
```
$ zfs list
NAME                              USED  AVAIL  REFER  MOUNTPOINT
rpool                            14.8G  52.6G    65K  none
rpool/ROOT                       14.8G  52.6G    65K  none
rpool/ROOT/delphix.MpOla39       14.8G  52.6G    64K  none
rpool/ROOT/delphix.MpOla39/home  6.60G  52.6G  6.60G  legacy
rpool/ROOT/delphix.MpOla39/log   29.8M  52.6G  29.8M  legacy
rpool/ROOT/delphix.MpOla39/root  8.14G  52.6G  8.14G  /
rpool/crashdump                  28.5K  34.7G  28.5K  legacy
rpool/docker                      334K  52.6G   334K  -
rpool/grub                       3.08M  52.6G  3.08M  legacy
rpool/public                       29K  52.6G    29K  /public
rpool/update                       30K  30.0G    30K  /var/dlpx-update
rpool/upgrade-logs                 29K  52.6G    29K  /var/tmp/delphix-upgrade

```

### delphix-platform.services logs after developer_reset
```
Nov 03 04:29:18 ip-10-110-218-78 relocate-var-delphix[35589]: engine is not initialized yet, skip relocating /var/delphix

```

logs after initialing the system again
```
Nov 03 04:31:02 ip-10-110-218-78 relocate-var-delphix[38882]: got current mounted filesystem of /var/delphix: rpool/ROOT/delphix.MpOla39/root
Nov 03 04:31:02 ip-10-110-218-78 relocate-var-delphix[38882]: start relocating /var/delphix from rpool/ROOT/delphix.MpOla39/root to domain0/delphix.MpOla39/data
Nov 03 04:31:02 ip-10-110-218-78 relocate-var-delphix[38882]: creating parent file system domain0/delphix.MpOla39
Nov 03 04:31:02 ip-10-110-218-78 relocate-var-delphix[38882]: creating filesystem domain0/delphix.MpOla39/data and mounting it to temp mountpoint /var/delphix-relocation-tmp
Nov 03 04:31:02 ip-10-110-218-78 relocate-var-delphix[38882]: copying files from /var/delphix to /var/delphix-relocation-tmp
Nov 03 04:31:03 ip-10-110-218-78 relocate-var-delphix[38882]: cleaning up mount record of /var/delphix in /etc/fstab
Nov 03 04:31:03 ip-10-110-218-78 relocate-var-delphix[38882]: warning: legacy filesystem not expected, expected rpool/ROOT/delphix.MpOla39/data but got rpool/ROOT/delphix.MpOla39/root, skipped
Nov 03 04:31:03 ip-10-110-218-78 relocate-var-delphix[38882]: mounting domain0/delphix.MpOla39/data to /var/delphix
Nov 03 04:31:03 ip-10-110-218-78 relocate-var-delphix[38882]: successfully relocated /var/delphix from rpool/ROOT/delphix.MpOla39/root to domain0/delphix.MpOla39/data

```


# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
