### PR TITLE
TOOL-16594 Don't remove delphix user from existing groups

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -31,6 +31,7 @@
     uid: 65433
     group: staff
     groups: root
+    append: true
     shell: /bin/bash
     create_home: yes
     comment: Delphix User


### PR DESCRIPTION
This change modifies the Ansible logic that is used to configure the
delphix user, such that the Ansible task will no longer remove the user
from any groups it already exists in.

This change is needed so that appliance-build can modify the groups the
user is in, based on the variant the build is producing. Without this
change, the build could assign the delphix user to a non-standard group,
but that configuration would get overwritten by this Ansible task.
