### PR TITLE
TOOL-16805 Configure swap device on buildserver systems

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -569,4 +569,6 @@
 # opted to automatically configure swap space here.
 #
 - include_tasks: swap.yml
-  when: variant == "internal-buildserver"
+  when:
+    - variant == "internal-buildserver"
+    - not ansible_is_chroot


### PR DESCRIPTION
We only want to run this when the system is actually booting, not during the build.