### PR TITLE
TOOL-16837 Improve build latency on DE based buildserver

### DIFF
--- a/files/common/lib/systemd/system/delphix-platform.service
+++ b/files/common/lib/systemd/system/delphix-platform.service
@@ -17,7 +17,7 @@
 [Unit]
 Description=Delphix Appliance Platform Service
 PartOf=delphix.target
-After=local-fs.target
+After=local-fs.target delphix-rpool-upgrade.service
 Before=rsync.service docker.service
 
 [Service]

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/buildserver.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/buildserver.yml
@@ -15,9 +15,29 @@
 #
 
 ---
+#
+# To improve build latency, we set the following properties:
+#
+# - recordsize: We've seen better IO utilization when using a larger
+#    than the default 128K recordsize; the "delphix-rpool-upgrade"
+#    service will enable the "large_blocks" pool feature.
+#
+# - sync: We don't support resuming builds after a reboot, so there's no
+#   need to preserve normal sync semantics.
+#
+- zfs:
+    name: "{{ root_container }}"
+    state: present
+    extra_zfs_properties:
+      recordsize: 1M
+      sync: disabled
+
 - command: swapon --show --noheadings
   register: show
 
+#
+# We've hit build failures when swap space is not available, so we've
+# opted to automatically configure swap space here.
 #
 # This is a bit awkward, but we've hardcoded the device we're using for
 # swap here, based on the assumption that the Delphix buildserver will

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -564,11 +564,7 @@
     mode: 0644
   with_items: '{{ motd_files.files }}'
 
-#
-# We've hit build failures when swap space is not available, so we've
-# opted to automatically configure swap space here.
-#
-- include_tasks: swap.yml
+- include_tasks: buildserver.yml
   when:
     - variant == "internal-buildserver"
     - not ansible_is_chroot

--- a/files/common/var/lib/delphix-platform/ansible/apply
+++ b/files/common/var/lib/delphix-platform/ansible/apply
@@ -20,6 +20,7 @@ set -o pipefail
 SOURCE_DIRECTORY="$(readlink -f "${BASH_SOURCE%/*}")"
 DLPX_ANSIBLE_DIRECTORY="${DLPX_ANSIBLE_DIRECTORY:-$SOURCE_DIRECTORY}"
 ROOT_FILESYSTEM=$(zfs list -Ho name /)
+ROOT_CONTAINER=$(dirname "$ROOT_FILESYSTEM")
 
 #
 # If we are running as part of live-build, the root of the appliance's
@@ -44,6 +45,7 @@ function apply_playbook() {
 		-c "$DLPX_ANSIBLE_CONNECTION" \
 		-i "$DLPX_ANSIBLE_INVENTORY" \
 		-e "root_filesystem=$ROOT_FILESYSTEM" \
+		-e "root_container=$ROOT_CONTAINER" \
 		-e "platform=$PLATFORM" \
 		-e "variant=$VARIANT" \
 		"$1"; then

--- a/files/common/var/lib/delphix-platform/rpool-upgrade
+++ b/files/common/var/lib/delphix-platform/rpool-upgrade
@@ -5,4 +5,5 @@ while read -r feature; do
 done <<-EOF
 	async_destroy
 	lz4_compress
+	large_block
 EOF


### PR DESCRIPTION
I've seen the build latency be significatly longer when using the
default 128K recordsize, so this change is to set the recordsize to 1M
on a buildserver variant for the root container datasets.
