### PR TITLE
DLPX-83991 Crash dump process provides no feedback

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2021 Delphix
+# Copyright 2018, 2023 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -504,7 +504,8 @@
 #       [1] Compress the dump (-c)
 #       [2] Filter out pages that are zero, in the page or private cache,
 #           part of user data, or marked as freed (-d 31)
-#       [3] Print common, error, and report messages (--message-level 22)
+#       [3] Output a progress indicator, common and error messages, and
+#           a report summary message (--message-level 23)
 #       [4] Exclude ZFS ARC file data pages
 #           (--private-page-filter 0x2F5ABDF11ECAC4E)
 #       * see man page makedumpfile(8) for more info
@@ -545,7 +546,7 @@
     line: "{{ item.line }}"
   with_items:
     - regex: '^#?MAKEDUMP_ARGS='
-      line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 22 --private-page-filter 0x2F5ABDF11ECAC4E"'
+      line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 23 --private-page-filter 0x2F5ABDF11ECAC4E"'
     - regex: '^#?KDUMP_CMDLINE_APPEND='
       line: 'KDUMP_CMDLINE_APPEND="reset_devices systemd.unit=kdump-tools-dump.service nr_cpus=1 irqpoll nousb ata_piix.prefer_ms_hyperv=0 panic=10"'
 


### PR DESCRIPTION
### Problem
When makedumpfile is generating a dump file, no progress is observed in
the system console.  Since this operation can take a long time, we should
provide some progress output.
### Solution
We can configure makedumpfile to provide progress output using the
message-level option.
### Testing Done
Tested by generating a panic with lots of dirty memory and observed that
the progress output is seen in the console.

Note that this was tested with DLPX-84173 which modifies makedumpfile to
output line feeds with the progress output so that the line buffering into
the console will show the progress.

![console-progress](https://user-images.githubusercontent.com/12415697/210891972-c24bda58-77ac-4d5c-8bd2-8efc3ce6ad7e.png)

### Deployment Plan
This PR should land after DLPX-83991 which addresses the buffering of the
progress output in the console.
