### PR TITLE
DLPX-84367 Need to add mandatory kernel parameters for Azure marketplace submission

### DIFF
--- a/files/azure/etc/cloud/cloud.cfg.d/91-azure.cfg
+++ b/files/azure/etc/cloud/cloud.cfg.d/91-azure.cfg
@@ -1,0 +1,5 @@
+#
+# Disable mounting the ephermeral device as /mnt
+#
+mounts:
+  - [ ephemeral0 ]

--- a/files/common/etc/default/grub.d/override.cfg
+++ b/files/common/etc/default/grub.d/override.cfg
@@ -126,3 +126,14 @@ GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT usbcore.nousb=1"
 # on a separate I/O timeout mechanism for correctness at the storage device layer.
 #
 GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT nvme_core.io_timeout=4294967295"
+
+#
+# Enable early boot messages to the console
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT earlyprintk=ttyS0,38400n8"
+
+#
+# Enable rootdelay as a requirement for Azure marketplace
+#
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT rootdelay=300"
+

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -346,6 +346,12 @@
     # especially since we aren't using any extensions.
     #
     - { key: 'AutoUpdate.Enabled', value: 'n' }
+    #
+    # This controls how the resource disk is provisioned. We don't
+    # currently use this disk so don't enable swap or format it.
+    #
+    - { key: 'ResourceDisk.Format', value: 'n' }
+    - { key: 'ResourceDisk.EnableSwap', value: 'n' }
   when: platform == "azure"
 
 #


### PR DESCRIPTION
This change add the `rootdelay` parameter which introduces a 5 minute delay during boot. As a result, this PR requires https://github.com/openzfs/zfs/pull/14430 to integrate first to avoid this regression.