### PR TITLE
TOOL-18958 Refactor how we set "OVF" in the datasource list

### DIFF
--- a/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
+++ b/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
@@ -113,3 +113,66 @@ datasource_list:
   - LXD
   - NWCS
   - None
+
+#
+# We hardcode the modules here, so that we carefully control what
+# cloud-init modules get executed.
+#
+
+cloud_init_modules:
+ - migrator
+ - seed_random
+ - bootcmd
+ - write-files
+ - growpart
+ - resizefs
+ - disk_setup
+ - mounts
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - ca-certs
+ - rsyslog
+ - ssh
+
+cloud_config_modules:
+ - wireguard
+ - snap
+ - ubuntu_autoinstall
+ - ssh-import-id
+ - keyboard
+ - locale
+ - grub-dpkg
+ - apt-pipelining
+ - apt-configure
+ - ubuntu-advantage
+ - ntp
+ - disable-ec2-metadata
+ - runcmd
+ - byobu
+
+cloud_final_modules:
+ - package-update-upgrade-install
+ - fan
+ - landscape
+ - lxd
+ - ubuntu-drivers
+ - write-files-deferred
+ - puppet
+ - chef
+ - ansible
+ - mcollective
+ - salt-minion
+ - reset_rmc
+ - refresh_rmc_and_interface
+ - rightscale_userdata
+ - scripts-vendor
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - keys-to-console
+ - install-hotplug
+ - phone-home
+ - final-message
+ - power-state-change

--- a/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
+++ b/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
@@ -38,15 +38,6 @@ system_info:
 manage_etc_hosts: true
 
 #
-# Since we're running on a ZFS-on-root installation, the "resizefs" and
-# "growpart" features of cloud init won't work; thus, we explicitly
-# disable them to help ensure they don't cause any harm.
-#
-resize_rootfs: false
-growpart:
-  mode: off
-
-#
 # Disable cloud-init from manipulating the APT sources. We don't want
 # the Delphix appliance to rely on packages from any 3rd party sources
 # (e.g. Ubuntu's APT repositories), so we need to ensure cloud-init does
@@ -124,55 +115,27 @@ cloud_init_modules:
  - seed_random
  - bootcmd
  - write-files
- - growpart
- - resizefs
- - disk_setup
- - mounts
- - set_hostname
- - update_hostname
  - update_etc_hosts
- - ca-certs
- - rsyslog
  - ssh
 
 cloud_config_modules:
  - wireguard
- - snap
  - ubuntu_autoinstall
  - ssh-import-id
  - keyboard
  - locale
  - grub-dpkg
  - apt-pipelining
- - apt-configure
- - ubuntu-advantage
  - ntp
- - disable-ec2-metadata
  - runcmd
- - byobu
 
 cloud_final_modules:
  - package-update-upgrade-install
- - fan
- - landscape
- - lxd
- - ubuntu-drivers
  - write-files-deferred
- - puppet
- - chef
- - ansible
- - mcollective
- - salt-minion
- - reset_rmc
- - refresh_rmc_and_interface
- - rightscale_userdata
  - scripts-vendor
  - scripts-per-once
  - scripts-per-boot
  - scripts-per-instance
  - scripts-user
- - keys-to-console
  - install-hotplug
- - phone-home
  - final-message
- - power-state-change

--- a/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
+++ b/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
@@ -78,3 +78,38 @@ ssh_deletekeys: false
 #
 vendor_data:
   enabled: false
+
+#
+# We need to control the order of the datasource list, so we override it
+# here, so that the dynamically created "90_dpkg.cfg" file doesn't take
+# affect. Specifically, we need OVF to be listed before NoCloud.
+#
+datasource_list:
+  - OVF
+  - NoCloud
+  - ConfigDrive
+  - OpenNebula
+  - DigitalOcean
+  - Azure
+  - AltCloud
+  - MAAS
+  - GCE
+  - OpenStack
+  - CloudSigma
+  - SmartOS
+  - Bigstep
+  - Scaleway
+  - AliYun
+  - Ec2
+  - CloudStack
+  - Hetzner
+  - IBMCloud
+  - Oracle
+  - Exoscale
+  - RbxCloud
+  - UpCloud
+  - VMware
+  - Vultr
+  - LXD
+  - NWCS
+  - None


### PR DESCRIPTION
I verified these overrides work as expected, and work to override the original configuration from both the `cloud.cfg` file and the `90_dpkg.cfg` file. The values I'm using to override were taken from an AWS engine, and copied the values as is.

Let me know if we should remove some values in this PR, or do that in a follow up PR. I'm OK either way.