### PR TITLE
DLPX-84733 Add "apt-configure" so dev variant can install packages

### DIFF
--- a/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
+++ b/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
@@ -131,6 +131,7 @@ cloud_config_modules:
  - locale
  - grub-dpkg
  - apt-pipelining
+ - apt-configure
  - ntp
  - runcmd
 


### PR DESCRIPTION
On developer systems, the intention is for us to be able to install
packages via the APT package manager, by communicating with Ubuntu's
servers. We regressed on this functionality when landing 584d5ac, so
this change is adding it back.
