### PR TITLE
CP-9700 Create super-user audit log directory

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -161,7 +161,7 @@
 - file:
     path: /var/delphix/log/session-logs
     state: directory
-    owner: delphix
+    group: staff
     mode: 0775
     recurse: yes
 

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -161,8 +161,9 @@
 - file:
     path: /var/delphix/log/session-logs
     state: directory
+    owner: delphix
     group: staff
-    mode: 0775
+    mode: 0700
     recurse: yes
 
 #

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -154,6 +154,18 @@
 - command: systemctl mask systemd-journald-audit.socket
 
 #
+# Create directory to store logs of all terminal activity by delphix
+# super users. These logs can be retrieved via a customer-facing API
+# for auditing purposes.
+#
+- file:
+    path: /var/delphix/log/session-logs
+    state: directory
+    owner: delphix
+    mode: 0775
+    recurse: yes
+
+#
 # The nfs-blkmap.service is disabled by default but since it is wanted
 # by nfs-client.target it will always get started.  We don't use pNFS
 # so mask the nfs-blkmap.service to keep it from running.


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

The Super User Audit project requires storing logs in a new folder. As these logs are not specific to masking or virtualization, they should be stored at a path outside of the files intended specifically for either engine. This folder needs to be pre-created during the platform build so that we can write logs to it later.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Create the folder at `/var/delphix/log/session-logs`

This location was chosen to follow general linux conventions, as well as our own, which have the virtualization and masking logs at `/var/delphix/server/log` and `/var/delphix/masking/logs` respectively. 

Note that `/var/delphix/log` does not yet exist. We could instead place the audit logs in `/var/delphix/session-logs` but it seemed cleaner to introduce a `log` folder now rather than potentially need to do it later should some other engine-agnostic logs be needed. `/var/log` also could be a reasonable spot for this. I am open to debate if others feel strongly.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Deployed a DCoA snapshot with ab-pre-push and verified the new folder was present:
```
delphix@ip-10-110-241-135:~$ ls -lrt /var/delphix
total 5
drwxrwxr-x  3 root    staff   3 Mar  6 22:39 log
drwxr-xr-x  9 root    root   9 Mar  6 22:39 server
drwxr-xr-- 24 masking staff 24 Mar  6 22:43 masking
delphix@ip-10-110-241-135:~$ ls -lrt /var/delphix/log
total 2
drwxrwxr-x 2 root staff 2 Mar  6 22:39 session-logs
delphix@ip-10-110-241-135:~$ ls -lrt /var/delphix/log/session-logs/
total 0
```
Note that `recurse` only sets permissions and ownership for the newly created directories. It does not modify parent directory permissions. E.g. on my updated engine:
```
delphix@ip-10-110-228-186:~$ ls -lrt /var
total 35
...
drwxrwxr-x  5 root root    5 Mar  7 19:14 delphix
...
delphix@ip-10-110-228-186:~$ ls -lrt /
total 54
...
drwxr-xr-x  17 root root   19 Mar  7 19:11 var
...
drwx------  11 root root   14 Mar  7 20:56 root
```
vs a stock 6.0/engine:
```
delphix@ip-10-110-250-248:~$ ls -lrt /var
total 35
drwxrwsr-x  2 root staff   2 Apr 15  2020 local
...
drwxrwxr-x  4 root root    4 Mar  6 21:23 delphix
...
delphix@ip-10-110-250-248:~$ ls -lrt /
total 56
...
drwxr-xr-x  17 root     root       19 Mar  6 21:20 var
...
drwx------   7 root     root       10 Mar  7 20:42 root
```
I also deployed the app-gate changes that initiate terminal logging via `script` and modify the `delphix` user's `.bashrc` to include a timestamp and verified I could still log in and that a session file was created in the appropriate directory. Those changes and their testing will be detailed in a [separate PR](https://github.com/delphix/dlpx-app-gate/pull/270).

git ab-pre-push --test-upgrade-from 8.0.0.0 -p aws -v internal-qa - 100%
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/4712/
</details>



<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->