### PR TITLE
DLPX-84972 increase zfs_txg_timeout from 5 to 50 to reduce I/O activity on mostly idle systems

### DIFF
--- a/files/common/lib/modprobe.d/10-zfs.conf
+++ b/files/common/lib/modprobe.d/10-zfs.conf
@@ -115,3 +115,10 @@ options zfs zvol_threads=256
 # link creation can get up to the order of a minute or more.
 #
 options zfs zfs_vdev_open_timeout_ms=180000
+
+#
+# Reduce the frequency of txg sync from its default of 5 seconds. This avoids
+# sending unnecessary I/O to the underlying storage when the system is mostly
+# idle.
+#
+options zfs zfs_txg_timeout=50


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Our internal DCoL infrastructure acts as a storage layer for hundreds of VMs and manages those VMs' lifecycles. The overall I/O load on a DCoL system (e.g. dcol1 or dcol2) is primarily a function of the I/O being generated by those VMs. When idle, those VMs each generate some I/O, on the order of 30-ish IOPs or 300KB/s. Individually, this is a drop in the bucket, but if you consider that there may be 700+ VMs running concurrently, the aggregate I/O generated even by idle VMs is significant.

Furthermore, the physical storage attached to dcol1 and dcol2 is already overloaded. We need to identify ways to reduce the load without necessarily reducing the value that we're getting out of the system.
</details>

<details open>
<summary><h2> Solution </h2></summary>

The solution is to reduce the amount of I/O that is generated by idle Delphix Engines. This was a strategy that was used long ago on the original dcenter, but was dropped along the way when DevOps transitioned to Linux-based DCoL a few years ago. See https://github.com/delphix/devops-gate/commit/d7822b5dde91a2e30821b9c4be4bd569c6e276ac for the original fix as it was applied to Illumos-based VMs at the time.

Here, we do the same thing, but for our Linux-based Delphix Engines. The solution is to increase the `zfs_txg_timeout` zfs parameter from 5 seconds to 50 seconds. For systems that are mostly idle from an I/O perspective, this reduces the frequency of txg sync operations. Because writes are being aggregated during that time (e.g. because on idle system most of the writes will be sequential writes to things like log files), the resulting writes performed during the txg sync will be for larger I/Os, but there will be fewer of them.

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Basic analysis of I/Os of an idle system before and after the fix, for a typical 10-minute interval:
before:
```
                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write                                        26             1686          1636184              281
```
after:
```
                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write                                         7             2077          1830291              135
```

Performance test results:
* AWS object storage: http://selfservice.jkennedy-abpp.dcol1.delphix.com/job/appliance-build-orchestrator-pre-push/64/consoleFull
* AWS block storage: http://selfservice.jkennedy-abpp.dcol1.delphix.com/job/appliance-build-orchestrator-pre-push/65/consoleFull
* Azure object storage: http://selfservice.jkennedy-abpp.dcol1.delphix.com/job/appliance-build-orchestrator-pre-push/66/consoleFull
* Azure block storage: http://selfservice.jkennedy-abpp.dcol1.delphix.com/job/appliance-build-orchestrator-pre-push/67/consoleFull

</details>