### PR TITLE
DLPX-85348 Performance degradation observed in the time taken by MSSQL VDB operation jobs

### DIFF
--- a/files/common/lib/modprobe.d/10-zfs.conf
+++ b/files/common/lib/modprobe.d/10-zfs.conf
@@ -115,10 +115,3 @@ options zfs zvol_threads=256
 # link creation can get up to the order of a minute or more.
 #
 options zfs zfs_vdev_open_timeout_ms=180000
-
-#
-# Reduce the frequency of txg sync from its default of 5 seconds. This avoids
-# sending unnecessary I/O to the underlying storage when the system is mostly
-# idle.
-#
-options zfs zfs_txg_timeout=50


### PR DESCRIPTION
The sgdisk command calls the sync() system call, which simply waits for dirty data to be written. It does not actually trigger zfs_sync() (i.e. a txg sync) to happen, which causes the sgdisk command to take at most 50 seconds to complete on an otherwise idle system (whereas before it would take at most 5 seconds).

This PR reverts the change that bumped the txg wait sync time from 5 to 50 seconds. We may be able to re-introduce that change if we figure out how to trigger a txg sync as part of the sync system call.
