### PR TITLE
DLPX-85228 GCP external images grant root access if ssh-keys is setup via the cloud provider

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/apply
+++ b/files/common/var/lib/delphix-platform/ansible/apply
@@ -26,7 +26,10 @@ ROOT_CONTAINER=$(dirname "$ROOT_FILESYSTEM")
 # If we are running as part of live-build, the root of the appliance's
 # filesystem won't be /
 #
-APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
+if [[ "$DLPX_ANSIBLE_CONNECTION" == "chroot" ]]; then
+	APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
+fi
+
 PLATFORM=$(cat "$APPLIANCE_ROOT_DIR/var/lib/delphix-appliance/platform")
 VARIANT=$(cat "$APPLIANCE_ROOT_DIR/usr/share/doc/delphix-entire-$PLATFORM/variant")
 
@@ -80,7 +83,7 @@ function apply_playbook() {
 #    continues to work, even if the ansible configuration doesn't have
 #    to be re-applied.
 #
-if [[ -f /var/lib/delphix-platform/ansible-done ]]; then
+if [[ -f "$APPLIANCE_ROOT_DIR/var/lib/delphix-platform/ansible-done" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
The problem is these lines, coupled with the fact that we switched from doing builds on Ubuntu, to doing builds on Delphix..

```
if [[ -f /var/lib/delphix-platform/ansible-done ]]; then
	exit 0
fi
```

So, on Ubuntu, the `/var/lib/delphix-platform/ansible-done` never exists, since this file is generated by the `delphix-platform` service. Thus, we never ran the `exit 0` line.. and properly applied the ansible configuration.

But, on Delphix, the `/var/lib/delphix-platform/ansible-done` does exist after the `delphix-platform` service runs to completion.

So, the problem is, when we first boot the Delphix buildserver, the platform service on the buildserver runs, and then creates this `/var/lib/delphix-platform/ansible-done` file. Then, later during the actual appliance-build, this script checks for the presence of `/var/lib/delphix-platform/ansible-done`, and sees that it exists, and bails early.

The check for `/var/lib/delphix-platform/ansible-done` was only intended to be used on the appliance during boot, not during appliance-build. So, now that we are running on a Delphix buildserver, we have to be careful not to look at the buildservers root file system when checking for the presence of the `/var/lib/delphix-platform/ansible-done` file.