### PR TITLE
DLPX-85453 [Backport of DLPX-85228 to 10.0.0.0] GCP external images grant root access if ssh-keys is setup via the cloud provider

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/apply
+++ b/files/common/var/lib/delphix-platform/ansible/apply
@@ -26,7 +26,10 @@ ROOT_CONTAINER=$(dirname "$ROOT_FILESYSTEM")
 # If we are running as part of live-build, the root of the appliance's
 # filesystem won't be /
 #
-APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
+if [[ "$DLPX_ANSIBLE_CONNECTION" == "chroot" ]]; then
+	APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
+fi
+
 PLATFORM=$(cat "$APPLIANCE_ROOT_DIR/var/lib/delphix-appliance/platform")
 VARIANT=$(cat "$APPLIANCE_ROOT_DIR/usr/share/doc/delphix-entire-$PLATFORM/variant")
 
@@ -80,7 +83,7 @@ function apply_playbook() {
 #    continues to work, even if the ansible configuration doesn't have
 #    to be re-applied.
 #
-if [[ -f /var/lib/delphix-platform/ansible-done ]]; then
+if [[ -f "$APPLIANCE_ROOT_DIR/var/lib/delphix-platform/ansible-done" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
Clean cherry-pick of #417 