### PR TITLE
DLPX-85467 Revert DLPX-85228

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/apply
+++ b/files/common/var/lib/delphix-platform/ansible/apply
@@ -26,10 +26,7 @@ ROOT_CONTAINER=$(dirname "$ROOT_FILESYSTEM")
 # If we are running as part of live-build, the root of the appliance's
 # filesystem won't be /
 #
-if [[ "$DLPX_ANSIBLE_CONNECTION" == "chroot" ]]; then
-	APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
-fi
-
+APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
 PLATFORM=$(cat "$APPLIANCE_ROOT_DIR/var/lib/delphix-appliance/platform")
 VARIANT=$(cat "$APPLIANCE_ROOT_DIR/usr/share/doc/delphix-entire-$PLATFORM/variant")
 
@@ -83,7 +80,7 @@ function apply_playbook() {
 #    continues to work, even if the ansible configuration doesn't have
 #    to be re-applied.
 #
-if [[ -f "$APPLIANCE_ROOT_DIR/var/lib/delphix-platform/ansible-done" ]]; then
+if [[ -f /var/lib/delphix-platform/ansible-done ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
without the revert:  http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5035/ 
reverting the latest  delphix-platform change on 6.0/stage http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5036/   -----> (We do not see the integration tests failing anymore. )

For the upgrade test that failed, I do not see that failure if I revert top of the zfs 6.0/stage change on top of reverting delphix-platform.
I do not have a root cause. At this point I am going to at least try to get dx-integration tests working by reverting this change