### PR TITLE
DLPX-85228 GCP external images grant root access if ssh-keys is setup via the cloud provider

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -167,6 +167,17 @@
     recurse: yes
 
 #
+# If the task above had to create the "/var/delphix" directory, the
+# permissions will not be correct, so we fix the permissions here.
+#
+- file:
+    path: /var/delphix
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+#
 # The nfs-blkmap.service is disabled by default but since it is wanted
 # by nfs-client.target it will always get started.  We don't use pNFS
 # so mask the nfs-blkmap.service to keep it from running.

--- a/files/common/var/lib/delphix-platform/ansible/apply
+++ b/files/common/var/lib/delphix-platform/ansible/apply
@@ -26,7 +26,10 @@ ROOT_CONTAINER=$(dirname "$ROOT_FILESYSTEM")
 # If we are running as part of live-build, the root of the appliance's
 # filesystem won't be /
 #
-APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
+if [[ "$DLPX_ANSIBLE_CONNECTION" == "chroot" ]]; then
+	APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
+fi
+
 PLATFORM=$(cat "$APPLIANCE_ROOT_DIR/var/lib/delphix-appliance/platform")
 VARIANT=$(cat "$APPLIANCE_ROOT_DIR/usr/share/doc/delphix-entire-$PLATFORM/variant")
 
@@ -80,7 +83,7 @@ function apply_playbook() {
 #    continues to work, even if the ansible configuration doesn't have
 #    to be re-applied.
 #
-if [[ -f /var/lib/delphix-platform/ansible-done ]]; then
+if [[ -f "$APPLIANCE_ROOT_DIR/var/lib/delphix-platform/ansible-done" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
## Problem

We introduced a regression after landing #417. The problem was, after that landed, the `delphix-postgres@default` service was failing to start; that service coming from the `delphix-virtualization` package.

The error from that service looks like this:
```
$ sudo systemctl status delphix-postgres@default.service
● delphix-postgres@default.service - Delphix default PostgreSQL database server
     Loaded: loaded (/lib/systemd/system/delphix-postgres@.service; enabled; vendor preset: enabled)
    Drop-In: /usr/lib/systemd/system/delphix-postgres@default.service.d
             └─default.conf
             /etc/systemd/system/delphix-postgres@.service.d
             └─override.conf
     Active: failed (Result: exit-code) since Sun 2023-04-02 03:34:03 UTC; 2min 29s ago
    Process: 7560 ExecStart=/opt/delphix/server/bin/svc-postgres -n default start (code=exited, status=1/FAILURE)

Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: delphix-postgres@default.service: Scheduled restart job, restart counter is at 5.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: Stopped Delphix default PostgreSQL database server.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: delphix-postgres@default.service: Start request repeated too quickly.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: delphix-postgres@default.service: Failed with result 'exit-code'.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: Failed to start Delphix default PostgreSQL database server.
```
```
$ sudo journalctl -u delphix-postgres@default.service | tail -20
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7560]: No manifest files to change ownership of
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7560]: /var/delphix/server/db is empty. Initialize it as PostgreSQL directory
Apr 02 03:34:03 mj-dx-test-3.dcol2 sudo[7586]:     root : TTY=unknown ; PWD=/usr/lib/postgresql/12/bin ; USER=postgres ; COMMAND=/usr/lib/postgresql/12/bin/initdb --encoding=UTF8 --locale=en_US.UTF-8 -D /var/delphix/server/db -U metadataservice
Apr 02 03:34:03 mj-dx-test-3.dcol2 sudo[7586]: pam_unix(sudo:session): session opened for user postgres by (uid=0)
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7593]: The files belonging to this database system will be owned by user "postgres".
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7593]: This user must also own the server process.
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7593]: The database cluster will be initialized with locale "en_US.UTF-8".
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7593]: The default text search configuration will be set to "english".
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7593]: Data page checksums are disabled.
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7593]: initdb: error: could not access directory "/var/delphix/server/db": Permission denied
Apr 02 03:34:03 mj-dx-test-3.dcol2 sudo[7586]: pam_unix(sudo:session): session closed for user postgres
Apr 02 03:34:03 mj-dx-test-3.dcol2 svc-postgres[7560]: svc-postgres: Could not initialize directory /var/delphix/server/db: 1
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: delphix-postgres@default.service: Control process exited, code=exited, status=1/FAILURE
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: delphix-postgres@default.service: Failed with result 'exit-code'.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: Failed to start Delphix default PostgreSQL database server.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: delphix-postgres@default.service: Scheduled restart job, restart counter is at 5.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: Stopped Delphix default PostgreSQL database server.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: delphix-postgres@default.service: Start request repeated too quickly.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: delphix-postgres@default.service: Failed with result 'exit-code'.
Apr 02 03:34:03 mj-dx-test-3.dcol2 systemd[1]: Failed to start Delphix default PostgreSQL database server.
```

## Root Cause

After some investigation, we determined this error is due to the fact that `/var/delphix` doesn't have the correct permissions. On a system generated after #417 was integrated, the permissions look like this:
```
$ ls -ld /var/delphix
drwx------ 4 delphix staff 4 Apr  3 05:06 /var/delphix
```
but prior to #417, the permissions look like this:
```
$ ls -ld /var/delphix
drwxrwxr-x 5 root root 5 Apr  3 05:09 /var/delphix
```

The `delphix-postgres@default` service needs access to the `/var/delphix/server/db` directory as the `postegres` user, but due to the permissions changes to `/var/delphix`, it no longer had the access it needed, resulting in the service failures.

After some debugging, we determine that #417 resulted in this change in permissions to the `/var/delphix` directory, indirectly, due to the changes made in #412.

It's a little complicated, but let me try to explain...

1. When we changed from using an Ubuntu based buildserver, to a Delphix based buildserver, we accidentally broke the ansible configuration that is supposed to be applied during the build, but didn't notice this breakage until recently.

2. #412 was integrated after we switched to a Delphix based buildserver, such that the ansible configuration it was adding never got tested and run during the build; it was only being run on first boot.

3. #417 fixed the build configuration logic such that we'd start correctly running the ansible configuration as part of the build process on a Delphix based buildserver.

4. As part of (3), the ansible configuration introduced in (2), was now running during the build, when previously it wasn't (i.e. it was previously only running on the DE on first boot).

Due to different run time environments at build time and first boot, the ansible configuration from (2) does slightly different things when run from the build, or run on first boot..
 
5. When it's run on first boot, the `/var/delphix` directory will already exist (due to the `/etc/fstab` entry, and the fact we mount a ZFS dataset at that path), so it won't need to create that directory; and thus, won't set that directory's permissions. Rather, the permissions of `/var/delphix` will simply be the default permissions for a directory.

6. When it's run during the build, the `/var/delphix` directory will not exist yet (because the ansible configuration is run prior to the ZFS dataset creation and mounting), so the task will create it, using the same permissions as the `/var/delphix/log/session-logs` directory that it's actually targeting; i.e. mode `0700` and owned by `delphix:staff`.

Thus, due to the bug from (1), we were using the behavior from (5). Once we fixed the bug from (1), we started to see the behavior from (6).

To verify this, here's what ansible tells us on first boot from a system without #417 (i.e. a system not configured properly at build time):
```
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]: changed: [localhost] => {
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:     "changed": true,
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:     "diff": {
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:         "after": {
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "group": 50,
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "mode": "0700",
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "owner": 65433,
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "path": "/var/delphix/log/session-logs",
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "state": "directory"
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:         },
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:         "before": {
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "group": 0,
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "mode": "0755",
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "owner": 0,
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "path": "/var/delphix/log/session-logs",
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:             "state": "absent"
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:         }
Apr 03 05:06:15 ip-10-110-228-74 apply[1513]:     },
```
i.e. this is saying, the `/var/delphix/log/session-logs` didn't previously exist, so it created it.

Here's what ansible tells us on first boot from a system that does have #417 (i.e. so it is configured during the build):
```
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]: ok: [localhost] => {
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:     "changed": false,
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:     "diff": {
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:         "after": {
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:             "path": "/var/delphix/log/session-logs"
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:         },
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:         "before": {
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:             "path": "/var/delphix/log/session-logs"
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:         }
Apr 03 05:06:09 ip-10-110-247-198 apply[1518]:     },
```
i.e. the `/var/delphix/log/session-logs` directory was already there, and was configured correctly, so nothing "changed" (the directory was created and configured during the build).

## Solution

Since the postgres service error ultimately is due to a misconfiguration of the `/var/delphix` directory, and since I didn't find any explicit configuration of that directory's permissions, the fix taken by this PR is to make the permissions of `/var/delphix` explicit. This way, no matter way the permissions are, we should correct them.