### PR TITLE
DLPX-85508 [Backport of DLPX-85228 to 10.0.0.0] GCP external images grant root access if ssh-keys is setup via the cloud provider

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -175,7 +175,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: 0775
 
 #
 # The nfs-blkmap.service is disabled by default but since it is wanted

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -167,6 +167,17 @@
     recurse: yes
 
 #
+# If the task above had to create the "/var/delphix" directory, the
+# permissions will not be correct, so we fix the permissions here.
+#
+- file:
+    path: /var/delphix
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+#
 # The nfs-blkmap.service is disabled by default but since it is wanted
 # by nfs-client.target it will always get started.  We don't use pNFS
 # so mask the nfs-blkmap.service to keep it from running.

--- a/files/common/var/lib/delphix-platform/ansible/apply
+++ b/files/common/var/lib/delphix-platform/ansible/apply
@@ -26,7 +26,10 @@ ROOT_CONTAINER=$(dirname "$ROOT_FILESYSTEM")
 # If we are running as part of live-build, the root of the appliance's
 # filesystem won't be /
 #
-APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
+if [[ "$DLPX_ANSIBLE_CONNECTION" == "chroot" ]]; then
+	APPLIANCE_ROOT_DIR="$SOURCE_DIRECTORY/../../../.."
+fi
+
 PLATFORM=$(cat "$APPLIANCE_ROOT_DIR/var/lib/delphix-appliance/platform")
 VARIANT=$(cat "$APPLIANCE_ROOT_DIR/usr/share/doc/delphix-entire-$PLATFORM/variant")
 
@@ -80,7 +83,7 @@ function apply_playbook() {
 #    continues to work, even if the ansible configuration doesn't have
 #    to be re-applied.
 #
-if [[ -f /var/lib/delphix-platform/ansible-done ]]; then
+if [[ -f "$APPLIANCE_ROOT_DIR/var/lib/delphix-platform/ansible-done" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
Clean backport of #421.

Not sure if we want to get this into 6.0/release, but opening the PR to get tests going, just in case.