### PR TITLE
DLPX-85228 GCP external images grant root access if ssh-keys is setup via the cloud provider

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -175,7 +175,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: 0775
 
 #
 # The nfs-blkmap.service is disabled by default but since it is wanted


### PR DESCRIPTION
In #421, I mistakenly set the permissions to `0755`, when they should actually be set to `0775` to match the permissions prior to #417.
