### PR TITLE
DLPX-82895 default value for "fs.inotify.max_user_watches" is insufficient for the scale release testing setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,46 +2,46 @@ on: [push, pull_request]
 
 jobs:
   check-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: docker build -t delphix-platform:latest docker
       - run: ./scripts/docker-run.sh make packages
   check-shellcheck:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: delphix/actions/shellcheck@master
   check-shfmt:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: delphix/actions/shfmt@master
   check-pylint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - run: python3 -m pip install pylint
       - run: python3 -m pip install netifaces
       - run: pylint -d invalid-name,E0611 files/common/usr/bin/delphix-startup-screen
   check-yapf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - run: python3 -m pip install yapf
       - run: yapf --diff --style google files/common/usr/bin/delphix-startup-screen
   check-mypy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - run: python3 -m pip install mypy
       - run: mypy --ignore-missing-imports files/common/usr/bin/delphix-startup-screen

--- a/files/common/lib/sysctl.d/50-override.conf
+++ b/files/common/lib/sysctl.d/50-override.conf
@@ -92,4 +92,4 @@ fs.mount-max = 300000
 # We've seen cases where we run out of this resource with the default
 # value of 8192, resulting in upgrade failures.
 #
-fs.inotify.max_user_watches = 16384
+fs.inotify.max_user_watches = 32768

--- a/files/common/usr/bin/delphix-startup-screen
+++ b/files/common/usr/bin/delphix-startup-screen
@@ -55,7 +55,7 @@ def get_svcs() -> List[str]:
     return cp.stdout.split("=", 1)[1].split()
 
 
-def run_svcs(options: str = None) -> Generator:
+def run_svcs(options: str = "") -> Generator:
     """
     Run the command to retrieve the status of all the services. The options
     argument can be used to obtain additional output from the 'systemctl'
@@ -245,7 +245,7 @@ def display_status(stdscr, win):
     status = 0
 
     x = int((X - width) / 2) + 2
-    y = (Y - height)
+    y = Y - height
 
     win.clear()
     win.box()


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

[DLPX-80760](https://delphix.atlassian.net/browse/DLPX-82895) addressed the same issue by increasing fs.inotify.max_user_watches from 8192 up to 16384 , but it appeared to be not enough for the scale release testing setup and one customer, New Jersey Manufacturers Insurance Company. The upgrade verify job fails because of that issue.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Increase fs.inotify.max_user_watches to 32768

Bonus: due to https://github.com/delphix/linux-pkg/pull/286, some modifications were needed to main.yml and delphix-startup-screen.py to pass Checks.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

ab-pre-push http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5212/console
Note: everything passed except upgrade which looks to be due to a flaky check
`Caught exception in test: <class 'blackbox.exceptions.BlackboxAssertionError'>: Source 'ORACLE_VIRTUAL_PDB_SOURCE-2' does not match its previous state on dlpx-qa-11000-bb-chain-4662-8532dd44.dlpxdc.co:`

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
