### PR TITLE
CP-9251 minimize vmtoolsd plugins

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
@@ -31,3 +31,9 @@
     state: reloaded
   listen: "sshd config changed"
   when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot
+
+- systemd:
+    name: open-vm-tools
+    state: restarted
+  listen: "vmware-tools config changed"
+  when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -595,6 +595,37 @@
     mode: 0644
   with_items: '{{ motd_files.files }}'
 
+#
+# The vmtoolsd daemon provides a wealth of information about the guest VM to
+# the host, and a lot of that information is superfluous. For example, the list
+# of filesystems mounted in the guest, or the list of processes running inside
+# the guest. Not only is this information superfluous to the VMware admin,
+# obtaining that information on a very large VM takes up precious CPU time. For
+# example, the list of disks and filesystems is by default obtained every 30
+# seconds, and when doing that, vmtoolsd does a statfs and lstat of every
+# single filesystem and mountpoint. On a Delphix Engine with tens-of-thousands
+# of timeflows, this is a large amount of churn.
+#
+# We disable the plugins responsible for this superfluous churn here.
+#
+- blockinfile:
+    path: /etc/vmware-tools/tools.conf
+    block: |
+      [guestinfo]
+      # Set to true to disable DiskInfo.
+      disable-query-diskinfo=true
+
+      [appinfo]
+      # Set to true to disable the appinfo plugin.
+      disabled=true
+
+      [servicediscovery]
+      # Set to true to disable the servicediscovery plugin.
+      disabled=true
+  when:
+    - platform == "vmware"
+  notify: "vmware-tools config changed"
+
 - include_tasks: buildserver.yml
   when:
     - variant == "internal-buildserver"


### PR DESCRIPTION
This disables some needless and heavy-handed vmware tools plugins. The Jira
issue and comments in the ansible role should be fairly self-explanatory.

Testing:

ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5223/
blackbox pre_checkin against a VM configured this way (to make sure this doesn't interfere with automation): http://selfservice.jenkins.delphix.com/job/blackbox-self-service/77676/

I manually tested this by copying the ansible configuration in place on a VM, removing the `/var/lib/delphix-platform/ansible-done` file, and restarting the `delphix-platform` service. I observed that the contents of the `/etc/vmware-tools/tools.conf` file were correct and that the `open-vm-tools.service` had been restarted as a side-effect of the ansible task:

```
root@guild:/etc/vmware-tools# cat tools.conf
[logging]
# Turns on logging globally. It can still be disabled for each domain.
# log = true

# Disables core dumps on fatal errors; they're enabled by default.
# enableCoreDump = false

# Defines the "vmsvc" domain, logging to file
# vmsvc.level = message
vmsvc.handler = file
# Setup file rotation - keep 3 files
vmsvc.maxOldLogFiles = 3
# Max log file size kept: 1 MB
vmsvc.maxLogSize = 1

# Defines the "vmtoolsd" domain, and disable logging for it.
# vmtoolsd.level = none
# BEGIN ANSIBLE MANAGED BLOCK
[guestinfo]
# Set to true to disable DiskInfo.
disable-query-diskinfo=true

[appinfo]
# Set to true to disable the appinfo plugin.
disabled=true

[servicediscovery]
# Set to true to disable the servicediscovery plugin.
disabled=true
# END ANSIBLE MANAGED BLOCK
```