### PR TITLE
DLPX-85748 delphix-startup-screen does not display management service if it becomes inactive

### DIFF
--- a/files/common/usr/bin/delphix-startup-screen
+++ b/files/common/usr/bin/delphix-startup-screen
@@ -186,31 +186,29 @@ def set_common_variables(stdscr) -> Tuple[int, int]:
     return X, Y
 
 
-def getstatus_pair(lst) -> Generator:
-    """
-    Process the status and return a list which is comprised of
-    ['service description', 'service status'].
-    """
-    for i in range(0, len(lst), 2):
-        yield lst[i:i + 2]
-
-
 def getstatus() -> str:
     """
-    Each service returns 2 lines -- one with the description and the
-    next line with the state.
+    Gets the status of each service, with each line containing service
+    state and description.
     """
     status = ""
-    for i in getstatus_pair(list(run_svcs("Description"))):
+
+    # `svcs_status` contains 3 elements for each service:
+    # Description, ActiveState and UnitFileState.
+    svcs_status = list(run_svcs("Description,UnitFileState"))
+
+    for i in range(0, len(svcs_status), 3):
+        desc, active_state, enabled_state = svcs_status[i:i + 3]
         #
-        # Don't print any inactive services
+        # Don't print any inactive services which are not enabled
         #
-        if i[-1].strip() == "inactive":
+        if (active_state.strip() == "inactive" and
+                enabled_state.strip() != "enabled"):
             continue
         #
-        # Switch the state and description
+        # Append the state and description of each service
         #
-        status += f"{i[-1]}\t{i[0]}\n"
+        status += f"{active_state}\t{desc}\n"
     return status
 
 


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Delphix startup screen doesn't display inactive services. It displays failed services but not inactive services. Sometimes, this information is important for `enabled` services (services which always start while booting).
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Always display the state of enabled services (even though they are inactive).
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5502/console
Tested my manually stopping postgres service and ensuring postgres and mgmt service both are showing as inactive. 
Also tested my simulating a postgres service failure, which shows postgres service as failed and mgmt service as inactive.
</details>
<img width="832" alt="Screen Shot 2023-05-19 at 1 47 09 PM" src="https://github.com/delphix/delphix-platform/assets/79942407/d8bfcb8e-c16b-4af9-acaa-f0a6f82c70ca">


<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
