### PR TITLE
DLPX-86152 eliminate debug symbols from the build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -71,7 +71,7 @@ DEPENDS += ansible, \
 #
 # The CRA PAM module provides an authentication method for the delphix user.
 #
-DEPENDS += pam-challenge-response
+DEPENDS += pam-challenge-response,
 
 # Platform-specific dependencies
 DEPENDS.aws = nvme-cli,

--- a/debian/rules
+++ b/debian/rules
@@ -68,30 +68,10 @@ DEPENDS += ansible, \
 	   ubuntu-minimal, \
 	   update-notifier-common,
 
-# Debugging symbols for packages pulled in by the the above dependencies
-DEPENDS += libblkid1-dbgsym, \
-	   libmount1-dbgsym, \
-	   libuuid1-dbgsym, \
-	   dbus-dbgsym, \
-	   libdbus-1-3-dbgsym, \
-	   openssh-server-dbgsym, \
-	   openssh-client-dbgsym, \
-	   coreutils-dbgsym, \
-	   bash-dbgsym, \
-	   iproute2-dbgsym, \
-	   net-tools-dbgsym,
-
-#
-# The following package contains the GPG keys which allow us to download
-# from the repositories which contain packages containing debug symbols.
-#
-DEPENDS += ubuntu-dbgsym-keyring,
-
 #
 # The CRA PAM module provides an authentication method for the delphix user.
 #
-DEPENDS += pam-challenge-response, \
-	   pam-challenge-response-dbgsym,
+DEPENDS += pam-challenge-response
 
 # Platform-specific dependencies
 DEPENDS.aws = nvme-cli,
@@ -127,12 +107,10 @@ DEPENDS += aptitude, \
 	   awscli, \
 	   bcc-tools, \
 	   bpftrace, \
-	   bpftrace-dbgsym, \
 	   crash-python, \
 	   delphix-rust, \
 	   dnsutils, \
 	   drgn, \
-	   drgn-dbgsym, \
 	   dstat, \
 	   emacs-nox, \
 	   ethtool, \
@@ -145,12 +123,9 @@ DEPENDS += aptitude, \
 	   jq, \
 	   kdump-tools, \
 	   ldap-utils, \
-	   libbcc-dbgsym, \
 	   libkdumpfile, \
-	   libkdumpfile-dbgsym, \
 	   linux-tools-common, \
 	   lsof, \
-	   makedumpfile-dbgsym, \
 	   man-db, \
 	   manpages, \
 	   manpages-dev, \
@@ -162,7 +137,6 @@ DEPENDS += aptitude, \
 	   procinfo, \
 	   psmisc, \
 	   ptools, \
-	   ptools-dbgsym, \
 	   pv, \
 	   savedump, \
 	   screen, \


### PR DESCRIPTION
eliminating debug packages from systems platform.

Testing: 
git grep dbgsym |wc -l
       0

On an engine, this is what is left:
delphix@ip-10-110-209-243:~$ apt list |grep dbg

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

dmidecode-dbgsym/now 3.2-3 amd64 [installed,local]
libcrypt-blowfish-dbgsym/now 1.3 amd64 [installed,local]
linux-image-5.4.0-1101-dx2023050323-a63f70b93-aws-dbgsym/now 5.4.0-1101.109 amd64 [installed,local]
nfs-common-dbgsym/now 1:1.3.4-delphix-2023.04.17.23 amd64 [installed,local]
nfs-kernel-server-dbgsym/now 1:1.3.4-delphix-2023.04.17.23 amd64 [installed,local]
postgresql-10-dbgsym/now 10.23-1.pgdg20.04+1 amd64 [installed,local]
zfs-dbg/now 2.1.99-delphix+2023.05.16.18 amd64 [installed,local]
zfs-modules-5.4.0-1101-dx2023050323-a63f70b93-aws-dbg/now 2.1.99-delphix+2023.05.16.18 amd64 [installed,local]


Without the fix:
delphix@ip-10-110-250-124:~$ apt list |grep dbg

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

bash-dbgsym/now 5.0-6ubuntu1.2 amd64 [installed,local]
bpftrace-dbgsym/now 1.0.0-delphix-2023.05.20.10 amd64 [installed,local]
coreutils-dbgsym/now 8.30-3ubuntu2 amd64 [installed,local]
dbus-dbgsym/now 1.12.16-2ubuntu2.3 amd64 [installed,local]
dmidecode-dbgsym/now 3.2-3 amd64 [installed,local]
drgn-dbgsym/now 1.0.0-delphix-2023.04.17.23 amd64 [installed,local]
iproute2-dbgsym/now 5.5.0-1ubuntu1 amd64 [installed,local]
libbcc-dbgsym/now 0.22.0-1-delphix-2023.04.17.23 amd64 [installed,local]
libblkid1-dbgsym/now 2.34-0.1ubuntu9.3 amd64 [installed,local]
libcrypt-blowfish-dbgsym/now 1.3 amd64 [installed,local]
libdbus-1-3-dbgsym/now 1.12.16-2ubuntu2.3 amd64 [installed,local]
libkdumpfile-dbgsym/now 0.3.0-delphix-2023.04.17.23 amd64 [installed,local]
libmount1-dbgsym/now 2.34-0.1ubuntu9.3 amd64 [installed,local]
libuuid1-dbgsym/now 2.34-0.1ubuntu9.3 amd64 [installed,local]
linux-image-5.4.0-1101-dx2023050323-a63f70b93-aws-dbgsym/now 5.4.0-1101.109 amd64 [installed,local]
makedumpfile-dbgsym/now 1:1.6.7-delphix-2023.04.17.23 amd64 [installed,local]
net-tools-dbgsym/now 1.60+git20180626.aebd88e-1ubuntu1 amd64 [installed,local]
nfs-common-dbgsym/now 1:1.3.4-delphix-2023.04.17.23 amd64 [installed,local]
nfs-kernel-server-dbgsym/now 1:1.3.4-delphix-2023.04.17.23 amd64 [installed,local]
openssh-client-dbgsym/now 1:8.2p1-4ubuntu0.7 amd64 [installed,local]
openssh-server-dbgsym/now 1:8.2p1-4ubuntu0.7 amd64 [installed,local]
pam-challenge-response-dbgsym/now 1.0.1 amd64 [installed,local]
postgresql-10-dbgsym/now 10.23-1.pgdg20.04+1 amd64 [installed,local]
ptools-dbgsym/now 0.2.0-delphix-2023.04.17.23 amd64 [installed,local]
ubuntu-dbgsym-keyring/now 2020.02.11.4 all [installed,local]
zfs-dbg/now 2.1.99-delphix+2023.05.16.18 amd64 [installed,local]
zfs-modules-5.4.0-1101-dx2023050323-a63f70b93-aws-dbg/now 2.1.99-delphix+2023.05.16.18 amd64 [installed,local]
