### PR TITLE
DLPX-86240 Restart zfs-zed.service during deferred upgrade

### DIFF
--- a/files/common/lib/systemd/system/zfs-zed.service.d/override.conf
+++ b/files/common/lib/systemd/system/zfs-zed.service.d/override.conf
@@ -1,0 +1,21 @@
+#
+# Copyright 2023 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[Unit]
+PartOf=delphix.target
+
+[Install]
+WantedBy=delphix.target


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

From the Jira issue:
```
As part of follow-up investigation to DLPX-85526: vdev_remove_wanted flag set on device, causes pool expansion to suspend domain0, we have realized zfs-zed.service is not currently restarted during deferred reboot.

As a result, fixes delivered to this service cannot be realized by customers without a reboot upgrade.

Bug is filed at request of ZFS engineering (George Wilson)
```
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Create an override such that zfs-zed is "WantedBy" delphix.target.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5645/

Manual tests:
1. Verify that the override/drop-in file was created
```
$ cat /lib/systemd/system/zfs-zed.service.d/override.conf
...
...
[Unit]
PartOf=delphix.target

[Install]
WantedBy=delphix.target
```

2. Verify that the zfs-zed service is now "WantedBy" delphix.target
```
$ systemctl list-dependencies delphix.target
delphix.target
● ├─delphix-mgmt.service
● ├─delphix-nginx.service
● ├─delphix-osadmin.service
● ├─delphix-platform.service
● ├─delphix-postgres@default.service
● ├─delphix-rollback.service
● ├─delphix-rpool-upgrade.service
● ├─delphix-stat.service
● ├─delphix-telegraf.service
● ├─docker.service
● └─zfs-zed.service
```

3. Restart delphix.target and verify zfs-zed restarts
```
delphix@ip-10-110-234-241:~$ systemctl status zfs-zed
● zfs-zed.service - ZFS Event Daemon (zed)
     Loaded: loaded (/lib/systemd/system/zfs-zed.service; enabled; vendor preset: enabled)
    Drop-In: /usr/lib/systemd/system/zfs-zed.service.d
             └─override.conf
     Active: active (running) since Thu 2023-06-01 16:18:05 UTC; 2min 9s ago
       Docs: man:zed(8)
   Main PID: 752 (zed)
      Tasks: 4 (limit: 8777)
     Memory: 2.5M
     CGroup: /system.slice/zfs-zed.service
             └─752 /usr/sbin/zed -F -v

delphix@ip-10-110-234-241:~$ sudo systemctl restart delphix.target

delphix@ip-10-110-234-241:~$ systemctl status zfs-zed
● zfs-zed.service - ZFS Event Daemon (zed)
     Loaded: loaded (/lib/systemd/system/zfs-zed.service; enabled; vendor preset: enabled)
    Drop-In: /usr/lib/systemd/system/zfs-zed.service.d
             └─override.conf
     Active: active (running) since Thu 2023-06-01 16:20:22 UTC; 2min 47s ago
       Docs: man:zed(8)
   Main PID: 6245 (zed)
      Tasks: 4 (limit: 8777)
     Memory: 1.3M
     CGroup: /system.slice/zfs-zed.service
             └─6245 /usr/sbin/zed -F -v

<--------- journalctl output --------->
Jun 01 16:20:22 ip-10-110-234-241 systemd[1]: Stopping ZFS Event Daemon (zed)...
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Exiting
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: zed_disk_event_fini
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: zfs_agent_consumer_thread: exiting
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Retire Agent: fmd.accepted: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Retire Agent: unregister module
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: fmd.accepted: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: fmd.caseopen: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: fmd.casesolved: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: fmd.caseclosed: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: old_drops: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: dev_drops: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: vdev_drops: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: import_drops: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: resource_drops: 0
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Diagnosis Engine: unregister module
Jun 01 16:20:22 ip-10-110-234-241 zed[752]: Add Agent: fini
Jun 01 16:20:22 ip-10-110-234-241 systemd[1]: zfs-zed.service: Succeeded.
Jun 01 16:20:22 ip-10-110-234-241 systemd[1]: Stopped ZFS Event Daemon (zed).
Jun 01 16:20:22 ip-10-110-234-241 systemd[1]: Started ZFS Event Daemon (zed).
Jun 01 16:20:22 ip-10-110-234-241 zed[6245]: Registered zedlet "all-syslog.sh"
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
