### PR TITLE
DLPX-86534 CIS: idle shell timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Log into that VM using the "ubuntu" user, and run these commands:
 
     $ git clone https://github.com/delphix/delphix-platform.git
     $ cd delphix-platform
+    $ sudo apt-get update && sudo apt-get install python3-docker
     $ ansible-playbook bootstrap/playbook.yml
     $ ./scripts/docker-run.sh make packages
 

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -262,7 +262,7 @@
 
 - blockinfile:
     path: /etc/profile
-    insertafter: BOF
+    insertafter: EOF
     block: |
       # Set a 5 minute idle timeout for all shells. After prompting for input
       # this timeout timer begins.

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -260,6 +260,23 @@
     #
     - variant is regex("external-.*")
 
+- blockinfile:
+    path: /etc/profile
+    insertafter: BOF
+    block: |
+      # Set a 5 minute idle timeout for all shells. After prompting for input
+      # this timeout timer begins.
+      TMOUT=300
+      readonly TMOUT
+      export TMOUT
+  when:
+    #
+    # For developer convenience, we only enable the shell timeout
+    # for external variants. The idle timeout can be a burden when we
+    # need to run long running processes over SSH on our internal
+    # systems (e.g. for development, testing, etc).
+    #
+    - variant is regex("external-.*")
 #
 # Harden the appliance by disabling SFTP.
 #


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>
Not having an idle timeout for a shell session creates an opertunity for attackers to make use of unattended shell sessions. While we do not provide a real shell offically for customers, many customers may unofficaly gain shell access. Support engineers can gain shell access. So with this change support engineers will be kicked out of idle shells.

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
Set TMOUT in /etc/profile. Make the setting readonly so that it cannot be overriden to extend the idle timeout. 
</details>


<details open>
<summary><h2> Testing Done </h2></summary>
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5818/

This job created multiple images. The internal dev qa image was imported as part of the usual appliance build orchestrator job. I manually verified that `/etc/profile` did not contain a timeout setting. I then re-ran `delphix-build-and-snapshots` job at http://selfservice.jenkins.delphix.com/job/delphix-build-and-snapshots/job/ami-snapshots/4175/console
to import the external image variant into DCoA. I logged into the shell via the CRA process (register the engine at register.delphix.com, and then getting the challenge response code from auth.delphix.com) confirmed that `/etc/profile` in this variant does have the timeout setting. I then proceeded to wait five minutes and was kicked out of my SSH session.
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->


<details open>
<summary><h2> Notes to Reviewers </h2></summary>

This five minute timeout may affect how support does their work and so the actual timeout may change after you have looked at this review depending on feedback from support.
</details>


<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
