### PR TITLE
DLPX-86596 Remove dependency on "ubuntu-minimal" meta-package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -44,29 +44,64 @@ DEPENDS += grub-pc, \
 	   delphix-zfs,
 
 #
-# The following packages provide the minimal set of packages that are
-# necessary to create a working system (e.g. networking, users, etc).
+# The following packages provide a "minimal" Ubuntu installation. This mimics
+# the "ubuntu-minimal" meta-package, but since that package includes more than
+# we want installed on the appliance, we can't use it directly. Additionally,
+# our appliance requires a few more packages than would be pulled in by
+# "ubuntu-minimal", and these additional packages are listed here.
 #
-DEPENDS += ansible, \
+DEPENDS += adduser, \
+	   ansible, \
+	   apt, \
+	   apt-utils, \
 	   auditd, \
+	   bzip2, \
 	   cloud-init, \
+	   console-setup, \
 	   cron, \
+	   debconf, \
+	   debconf-i18n, \
 	   debootstrap, \
 	   debsums, \
 	   dmidecode, \
+	   eject, \
+	   init, \
+	   initramfs-tools, \
+	   iproute2, \
+	   iputils-ping, \
+	   isc-dhcp-client, \
+	   kbd, \
+	   kmod, \
+	   less, \
+	   locales, \
 	   logrotate, \
+	   lsb-release, \
+	   mawk, \
+	   mount, \
 	   net-tools, \
+	   netbase, \
+	   netcat-openbsd, \
+	   netplan.io, \
 	   ntp, \
 	   open-iscsi, \
 	   openssh-server, \
 	   openssl, \
+	   passwd, \
 	   policykit-1, \
+	   procps, \
 	   python3, \
 	   rng-tools, \
 	   rsyslog, \
+	   sensible-utils, \
+	   sudo, \
 	   systemd-container, \
-	   ubuntu-minimal, \
-	   update-notifier-common,
+	   tzdata, \
+	   ubuntu-advantage-tools, \
+	   ubuntu-keyring, \
+	   udev, \
+	   update-notifier-common, \
+	   vim-tiny, \
+	   whiptail,
 
 #
 # The CRA PAM module provides an authentication method for the delphix user.


### PR DESCRIPTION
### Problem

We've found that "ubuntu-minimal" has package dependencies that should not be installed on our appliance, some actually result in customer problems. Since our "delphix-platform" package depends on "ubuntu-minimal", we're unable to remove these packages from our appliance (removal of the packages would break package dependencies).

### Solution

The solution taken in this change, is to modify the "delphix-platform" package, such that it no longer depends on "ubuntu-minimal". Instead, we're depending directly on the same packages that "ubuntu-minimal" currently depends on, but not depending on "ubuntu-minimal". This way, we should be able to remove any of these packages individually, if any of them do not belong installed on the appliance.

### Why?

Without this change, if we tried to remove one of these packages, we'd have to remove the "ubuntu-minimal" package, which would then require the removal of "delphix-platform" and all of our packages that depend on "delphix-platform" (e.g. "delphix-virtualization").

### Testing

- Ran `dpkg-query -Wf '${Package}\n'` before and after, and verified the difference:
```
$ diff -u before.txt after.txt
--- before.txt  2023-06-16 01:23:06.391984740 +0000
+++ after.txt   2023-06-16 01:22:48.035985653 +0000
@@ -691,7 +691,6 @@
 tzdata
 ubuntu-advantage-tools
 ubuntu-keyring
-ubuntu-minimal
 ubuntu-mono
 ubuntu-release-upgrader-core
 ucf
 ```
 i.e. the only difference is we no longer have the `ubuntu-minimal` package installed.