### PR TITLE
DLPX-86598 Remove "ubuntu-advantage-tools" package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -96,7 +96,6 @@ DEPENDS += adduser, \
 	   sudo, \
 	   systemd-container, \
 	   tzdata, \
-	   ubuntu-advantage-tools, \
 	   ubuntu-keyring, \
 	   udev, \
 	   update-notifier-common, \

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -626,6 +626,18 @@
     - platform == "vmware"
   notify: "vmware-tools config changed"
 
+#
+# In a prior release, the "ubuntu-advantage-tools" package may have
+# dynamically generated this file as part of its "postinst" package
+# hook. This file can result in upgrade problems, so we ensure it's
+# absent. We can't rely on the file being automatically removed, because
+# it was dynamically generated, and thus not removed by the package
+# manager when the package is removed.
+#
+- file:
+    path: "/etc/apt/sources.list.d/ubuntu-esm-infra.list"
+    state: absent
+
 - include_tasks: buildserver.yml
   when:
     - variant == "internal-buildserver"


### PR DESCRIPTION
### Problem

The "ubuntu-advantage-tools" package is unnecesary to have installed on the appliance, and has actually caused customer problems; e.g. ESCL-4493.

### Solution

Remove the "ubuntu-advantage-tools" package.
