### PR TITLE
DLPX-86624 remove unneeded packages once included by ubuntu-minimal

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -50,37 +50,26 @@ DEPENDS += grub-pc, \
 # our appliance requires a few more packages than would be pulled in by
 # "ubuntu-minimal", and these additional packages are listed here.
 #
-DEPENDS += adduser, \
-	   ansible, \
+DEPENDS += ansible, \
 	   apt, \
-	   apt-utils, \
 	   auditd, \
-	   bzip2, \
 	   cloud-init, \
 	   console-setup, \
 	   cron, \
-	   debconf, \
-	   debconf-i18n, \
 	   debootstrap, \
 	   debsums, \
 	   dmidecode, \
-	   eject, \
 	   init, \
-	   initramfs-tools, \
 	   iproute2, \
 	   iputils-ping, \
-	   isc-dhcp-client, \
 	   kbd, \
 	   kmod, \
 	   less, \
-	   locales, \
 	   logrotate, \
 	   lsb-release, \
-	   mawk, \
 	   mount, \
 	   net-tools, \
 	   netbase, \
-	   netcat-openbsd, \
 	   netplan.io, \
 	   ntp, \
 	   open-iscsi, \
@@ -92,15 +81,10 @@ DEPENDS += adduser, \
 	   python3, \
 	   rng-tools, \
 	   rsyslog, \
-	   sensible-utils, \
 	   sudo, \
 	   systemd-container, \
 	   tzdata, \
-	   ubuntu-keyring, \
-	   udev, \
-	   update-notifier-common, \
-	   vim-tiny, \
-	   whiptail,
+	   udev,
 
 #
 # The CRA PAM module provides an authentication method for the delphix user.


### PR DESCRIPTION
#437 removed our dependency on the `ubuntu-minimal` package by replacing it
with all of its dependencies (resulting in no actual packaging changes other
than the removal of the `ubuntu-minimal` package itself). This change enables
us to start removing unneeded packages that were previously always included as
dependencies from `ubuntu-minimal`. For example, #438 removed
ubuntu-advantage-tools.

This PR covers the removal of another round of related package-fat trimming. Of
the packages added to the dependency list by #437, we're removing those that
are of no use to our platform.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5824

Here's the diff of installed packages resulting from this PR:
```
~ ❯ diff apt-before.txt apt-after.txt
8d7
< apt-utils
52d50
< debconf-i18n
69d66
< distro-info
80d76
< eject
344d339
< libnewt0.52
446d440
< libtext-charwidth-perl
448,449d441
< libtext-iconv-perl
< libtext-wrapi18n-perl
546d537
< netcat-openbsd
605d595
< python3-dbus
607d596
< python3-debian
609,610d597
< python3-distro-info
< python3-distupgrade
647d633
< python3-update-manager
697d682
< ubuntu-advantage-tools
700d684
< ubuntu-release-upgrader-core
705,706d688
< update-manager-core
< update-notifier-common
711d692
< vim-tiny
715d695
< whiptail
```

Note that `ubuntu-advantage-tools` was not meant to be on this "before" list due to #438, but it appears that the package was still installed due to `update-notifier-common` depending on it. Because we're now removing `update-notifier-common`, `ubuntu-advantage-tools` finally gets jettisoned.