### PR TITLE
TOOL-21734 appliance-build-stage1 fails because package locales is missing

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -65,6 +65,7 @@ DEPENDS += ansible, \
 	   kbd, \
 	   kmod, \
 	   less, \
+	   locales, \
 	   logrotate, \
 	   lsb-release, \
 	   mount, \


### PR DESCRIPTION
This re-adds the `locales` package that was removed by #439. It looks like the
package needs to be on the build server (which we don't test), or on the engine
itself for not-in-place upgrades (which we don't test). The lack of testing of
both of these use cases is why this didn't get caught pre-commit in #439.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/github/job/delphix/job/delphix-platform/job/appliance-build-orchestrator/job/pre-push/254/
