### PR TITLE
DLPX-86598 Remove "ubuntu-advantage-tools" package

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -23,11 +23,6 @@ configure)
 	systemctl disable apt-daily-upgrade.service
 	systemctl disable apt-daily-upgrade.timer
 
-	systemctl disable ubuntu-advantage.service
-	systemctl disable ua-reboot-cmds.service
-	systemctl disable ua-timer.service
-	systemctl disable ua-timer.timer
-
 	#
 	# We need to make sure that the motd-news.service is disabled. This
 	# service reaches out to a public Ubuntu news service over the public


### PR DESCRIPTION
This is a continuation of: https://github.com/delphix/delphix-platform/pull/438 .. we should have made this change originally, but as-is, it causes upgrade failures:
```
# apt-get install -y "delphix-platform-aws"
Reading package lists... Done
...
Setting up delphix-platform-aws (1.0.0-delphix-2023.06.28.04) ...
+ case $1 in
+ systemctl disable apt-daily.service
+ systemctl disable apt-daily.timer
+ systemctl disable apt-daily-upgrade.service
+ systemctl disable apt-daily-upgrade.timer
+ systemctl disable ubuntu-advantage.service
Failed to disable unit: Unit file ubuntu-advantage.service does not exist.
dpkg: error processing package delphix-platform-aws (--configure):
 installed delphix-platform-aws package post-installation script subprocess returned error exit status 1
dpkg: dependency problems prevent configuration of delphix-virtualization:
 delphix-virtualization depends on delphix-platform; however:
  Package delphix-platform is not installed.
  Package delphix-platform-aws which provides delphix-platform is not configured yet.

dpkg: error processing package delphix-virtualization (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of delphix-masking:
 delphix-masking depends on delphix-virtualization; however:
  Package delphix-virtualization is not configured yet.

dpkg: error processing package delphix-masking (--configure):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 delphix-platform-aws
 delphix-virtualization
 delphix-masking
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

- `git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5969/)