### PR TITLE
DLPX-86032 DelphixFatalException raised in DB_REFRESH job during the derailer load on Scale setup having upgraded kernel

### DIFF
--- a/files/common/lib/modprobe.d/10-zfs.conf
+++ b/files/common/lib/modprobe.d/10-zfs.conf
@@ -115,3 +115,10 @@ options zfs zvol_threads=256
 # link creation can get up to the order of a minute or more.
 #
 options zfs zfs_vdev_open_timeout_ms=180000
+
+#
+# Wait up to 1 minute when opening a ZVOL. We've found the defualt value
+# is insufficient for some workloads (e.g. scale testing), resulting in
+# VDB errors (e.g. MSSQL VDB refresh failing).
+#
+options zfs zvol_open_timeout_ms=60000


### PR DESCRIPTION
### Problem

We see VDB refresh (and other operations) fail, and we've narrowed it down to `zvol_open` returning `ERESTARTSYS` to userspace (e.g. `sgdisk`). We only see this on the 5.15 kernel, not the 5.4 kernel used for the prior release.

Previously, on 5.4, the kernel would retry the `zvol_open` indefinitely when this error is returned. This retry logic was removed in 5.15, and to compensate, a retry was added to the ZFS logic within `zvol_open`. The problem, though, is the retry logic within `zvol_open` will stop retrying after a set amount of time (default set to 1 second).

Thus, due to this timeout, we still see the `ERESTARTSYS` error being returned to the caller on scale workloads, resulting in the VDB operation failures.

### Solution

This change increases the timeout to 1 minute (from 1 second), which is hopefully large enough to prevent failures for all Delphix workloads.

### Related Work

- https://github.com/openzfs/zfs/pull/15023
- https://github.com/delphix/zfs/pull/980