### PR TITLE
DLPX-86538 CIS: crontab file permissions

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -75,7 +75,8 @@
 
 #
 # Restrict cron permissions. All jobs are owned by root so there's no
-# reason to allow others any level of access.
+# reason to allow others any level of access. This is also necessary to
+# satisfy external auditing of CIS security benchmarks.
 #
 - file:
     path: /etc/crontab
@@ -83,29 +84,15 @@
     mode: 0600
 
 - file:
-    path: /etc/cron.d
+    path: "{{ item }}"
     state: directory
     mode: 0700
-
-- file:
-    path: /etc/cron.hourly
-    state: directory
-    mode: 0700
-
-- file:
-    path: /etc/cron.daily
-    state: directory
-    mode: 0700
-
-- file:
-    path: /etc/cron.weekly
-    state: directory
-    mode: 0700
-
-- file:
-    path: /etc/cron.monthly
-    state: directory
-    mode: 0700
+  with_items:
+    - /etc/cron.d
+    - /etc/cron.hourly
+    - /etc/cron.daily
+    - /etc/cron.weekly
+    - /etc/cron.monthly
 
 #
 # Create the directory and ZFS dataset that we'll use to store unpacked

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -74,8 +74,8 @@
     mode: 01777
 
 #
-# Restrict cronjob permissions. All jobs are owned by root so no need to
-# allow others to take a peek.
+# Restrict cron permissions. All jobs are owned by root so there's no
+# reason to allow others any level of access.
 #
 - file:
     path: /etc/crontab

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -63,7 +63,7 @@
 #
 # Create a world writeable directory for application and kernel core
 # dumps. We want it world writeable because we're sharing one directory
-# for corefiles from any user. Unlike illumos where all appliacation
+# for corefiles from any user. Unlike illumos where all application
 # cores are written out as the root user, linux cores are written with
 # the UID of the running process.
 #
@@ -71,6 +71,40 @@
     path: /var/crash
     state: directory
     mode: 0777
+
+#
+# Restrict cronjob permissions. All jobs are owned by root so no need to
+# allow others to take a peek.
+#
+- file:
+    path: /etc/crontab
+    state: present
+    mode: 0600
+
+- file:
+    path: /etc/cron.d
+    state: directory
+    mode: 0700
+
+- file:
+    path: /etc/cron.hourly
+    state: directory
+    mode: 0700
+
+- file:
+    path: /etc/cron.daily
+    state: directory
+    mode: 0700
+
+- file:
+    path: /etc/cron.weekly
+    state: directory
+    mode: 0700
+
+- file:
+    path: /etc/cron.monthly
+    state: directory
+    mode: 0700
 
 #
 # Create the directory and ZFS dataset that we'll use to store unpacked

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -79,7 +79,7 @@
 #
 - file:
     path: /etc/crontab
-    state: present
+    state: file
     mode: 0600
 
 - file:


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Qualys has reported that we have unnecessarily broad permissions set on `/etc/crontab` and `/etc/cron.*`. e.g.:

```
delphix@ip-10-110-244-209:~$ ls -lrt /etc | grep cron
-rw-r--r-- 1 root    root     722 Nov 16  2017 crontab
drwxr-xr-x 2 root    root       3 Jan 13  2022 cron.hourly
drwxr-xr-x 2 root    root       6 Jan 13  2022 cron.d
drwxr-xr-x 2 root    root       4 Jan 13  2022 cron.monthly
drwxr-xr-x 2 root    root       6 Jan 13  2022 cron.weekly
drwxr-xr-x 2 root    root      16 Jan 13  2022 cron.daily
```

There is no reason to allow group or world access to these. Also, as the saying goes, happy Qualys makes for... happy Koalas?
</details>

<details open>
<summary><h2> Solution </h2></summary>

Set permissions for `/etc/crontab` to 0600 and `/etc/cron.*` to 0700.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Deployed a snapshot to DCoA using ab-pre-push and confirmed the new permissions were set:

```
delphix@ip-10-110-205-71:~$ sudo ls -lrt /etc | grep cron
-rw------- 1 root     root      1042 Feb 13  2020 crontab
drwx------ 2 root     root         3 Jun 29 23:21 cron.hourly
drwx------ 2 root     root         6 Jun 29 23:21 cron.d
drwx------ 2 root     root         5 Jun 29 23:21 cron.weekly
drwx------ 2 root     root         4 Jun 29 23:21 cron.monthly
drwx------ 2 root     root        13 Jun 29 23:22 cron.daily
```

git ab-pre-push --test-upgrade-from 12.0.0.0
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/6013/

</details>
