### PR TITLE
DLPX-86834 replace mtr with mtr-tiny

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -149,7 +149,7 @@ DEPENDS += aptitude, \
 	   manpages, \
 	   manpages-dev, \
 	   memstat, \
-	   mtr, \
+	   mtr-tiny, \
 	   ncdu, \
 	   pciutils, \
 	   performance-diagnostics, \


### PR DESCRIPTION
The mtr package is a pig. The security team recently received a vulnerability notice for libcups2, a printing library. Naturally, the question was asked: Why on earth does our product include a printing library? The answer is that the mtr package depends on libgtk2.0-0 (to support the mtr command’s --gtk command-line flag which can make use of an X11 GUI), which in turn depends on libcups2.

It turns out that mtr can be compiled without gtk support. It also turns out that Ubuntu has an alternative package that includes the GUI-less mtr command that was compiled this way called mtr-tiny. This latter package is much more appropriate for Delphix.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/github/job/delphix/job/delphix-platform/job/appliance-build-orchestrator/job/pre-push/265/

Once this build completes, I'll manually verify that the resulting mtr binary works.
