### PR TITLE
DLPX-86902 failed to upgrade from 13.0.0.0 to 14.0.0.0 because engine should allow deferred

### DIFF
--- a/files/common/etc/kernel/postinst.d/update-notifier
+++ b/files/common/etc/kernel/postinst.d/update-notifier
@@ -1,0 +1,1 @@
+/usr/share/update-notifier/notify-reboot-required

--- a/files/common/usr/share/update-notifier/notify-reboot-required
+++ b/files/common/usr/share/update-notifier/notify-reboot-required
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$0" = "/etc/kernel/postinst.d/update-notifier" ]; then
+	DPKG_MAINTSCRIPT_PACKAGE=linux-base
+fi
+
+echo "*** System restart required ***" >/var/run/reboot-required
+echo "$DPKG_MAINTSCRIPT_PACKAGE" >>/var/run/reboot-required.pkgs


### PR DESCRIPTION
In 25ebf3493ddbd6bd27887e72a527716a1c181ca4 we removed the `update-notifier-common` package, which provides the `/usr/share/update-notifier/notify-reboot-required` script. This script is used by kernel packages to create the `/var/run/reboot-required` file, which is used by our product's upgrade logic to determine if a `FINISH_DEFERRED` upgrade is required to reach the `RUNNING` state.

As a result, without the `notify-reboot-required` on the engine, the `/var/run/reboot-required` does not get created anymore.

This change adds the `update-notifier-common` back.