### PR TITLE
DLPX-86934 failed to upgrade from earlier versions to 13.0.0.0 because exception from installing packages.list.gz file

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -31,7 +31,7 @@ Package: delphix-platform-@@TARGET_PLATFORM@@
 Provides: delphix-platform
 Conflicts: delphix-platform
 Architecture: any
-Replaces: base-files
+Replaces: base-files, update-notifier-common
 Depends: ${misc:Depends}, ${delphix:Depends}
 Description: Delphix Appliance Platform
   This package provides the base platform of the Delphix Appliance. It contains

--- a/files/common/usr/bin/get-appliance-version
+++ b/files/common/usr/bin/get-appliance-version
@@ -56,7 +56,6 @@ while [[ $# -gt 0 ]]; do
 	case "$1" in
 	-h | --help)
 		usage
-		break
 		;;
 	-M | --major)
 		echo "$output" | cut -d'.' -f1,2 | tr -d '\n'

--- a/files/common/usr/bin/get-property-from-image
+++ b/files/common/usr/bin/get-property-from-image
@@ -28,7 +28,7 @@ function die() {
 		exit_code=1
 	fi
 	echo "$(basename "$0"): $*" >&2
-	exit ${exit_code}
+	exit "${exit_code}"
 }
 
 function usage() {
@@ -38,6 +38,7 @@ function usage() {
 }
 
 function cleanup() {
+	# shellcheck disable=SC2317
 	[[ -n "$UNPACK_DIR" ]] && [[ -d "$UNPACK_DIR" ]] && rm -rf "$UNPACK_DIR"
 }
 

--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -26,7 +26,7 @@ function die() {
 		exit_code=1
 	fi
 	echo "$(basename "$0"): $*" >&2
-	exit ${exit_code}
+	exit "${exit_code}"
 }
 
 function usage() {
@@ -40,6 +40,7 @@ function report_progress_inc() {
 }
 
 function cleanup() {
+	# shellcheck disable=SC2317
 	[[ -n "$UNPACK_DIR" ]] && [[ -d "$UNPACK_DIR" ]] && rm -rf "$UNPACK_DIR"
 }
 


### PR DESCRIPTION
### Problem

In 59ecd44056b32f8c2378ea286212899fdbb38576 we added a file that conflicts with a file provided by the `update-notifier-common` package, but we never updated the package metadata to state this. As a result, when the `delphix-platform` package is installed on upgrades to 13, it'll get installed with the `update-notifier-common` package already installed on the system, and due to the file conflict, that install will fail.

### Solution

We need to update the `delphix-platform` package's metadata, to inform the package manager that this conflict is expected, and have the new version of the file(s) we install overwrite the versions provided by the `update-notifier-common` package. We do this with the `Replaces` directive.

### Testing

- `git-ab-pre-push --test-upgrade-from 12.0.0.0` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/6181/)

- Before on 12.0 system:
```
$ sudo apt-get install ./delphix-platform-aws_1.0.0-delphix.2023.07.12.22.00_amd64.deb
...
Unpacking delphix-platform-aws (1.0.0-delphix.2023.07.12.22.00) over (1.0.0-delphix-2023.06.08.15) ...
dpkg: error processing archive /export/home/delphix/before/delphix-platform-aws_1.0.0-delphix.2023.07.12.22.00_amd64.deb (--unpack):
 trying to overwrite '/usr/share/update-notifier/notify-reboot-required', which is also in package update-notifier-common 3.192.30.17
+ case $1 in
+ exit 0
Errors were encountered while processing:
 /export/home/delphix/before/delphix-platform-aws_1.0.0-delphix.2023.07.12.22.00_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

- After on 12.0 system:
```
$ sudo apt-get install ./delphix-platform-aws_1.0.0-delphix.2023.07.13.16.32_amd64.deb
...
Unpacking delphix-platform-aws (1.0.0-delphix.2023.07.13.16.32) over (1.0.0-delphix-2023.06.08.15) ...
Replacing files in old package update-notifier-common (3.192.30.17) ...
...

$ dpkg-query -S /usr/share/update-notifier/notify-reboot-required
delphix-platform-aws: /usr/share/update-notifier/notify-reboot-required
$ dpkg-query -S /etc/kernel/postinst.d/update-notifier
delphix-platform-aws: /etc/kernel/postinst.d/update-notifier
```