### PR TITLE
DLPX-86935 [Forward port of DLPX-86934] failed to upgrade from earlier versions to 13.0.0.0 because exception from installing packages.list.gz file

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -31,7 +31,7 @@ Package: delphix-platform-@@TARGET_PLATFORM@@
 Provides: delphix-platform
 Conflicts: delphix-platform
 Architecture: any
-Replaces: base-files
+Replaces: base-files, update-notifier-common
 Depends: ${misc:Depends}, ${delphix:Depends}
 Description: Delphix Appliance Platform
   This package provides the base platform of the Delphix Appliance. It contains

--- a/files/common/usr/bin/get-appliance-version
+++ b/files/common/usr/bin/get-appliance-version
@@ -56,7 +56,6 @@ while [[ $# -gt 0 ]]; do
 	case "$1" in
 	-h | --help)
 		usage
-		break
 		;;
 	-M | --major)
 		echo "$output" | cut -d'.' -f1,2 | tr -d '\n'

--- a/files/common/usr/bin/get-property-from-image
+++ b/files/common/usr/bin/get-property-from-image
@@ -28,7 +28,7 @@ function die() {
 		exit_code=1
 	fi
 	echo "$(basename "$0"): $*" >&2
-	exit ${exit_code}
+	exit "${exit_code}"
 }
 
 function usage() {
@@ -38,6 +38,7 @@ function usage() {
 }
 
 function cleanup() {
+	# shellcheck disable=SC2317
 	[[ -n "$UNPACK_DIR" ]] && [[ -d "$UNPACK_DIR" ]] && rm -rf "$UNPACK_DIR"
 }
 

--- a/files/common/usr/bin/unpack-image
+++ b/files/common/usr/bin/unpack-image
@@ -26,7 +26,7 @@ function die() {
 		exit_code=1
 	fi
 	echo "$(basename "$0"): $*" >&2
-	exit ${exit_code}
+	exit "${exit_code}"
 }
 
 function usage() {
@@ -40,6 +40,7 @@ function report_progress_inc() {
 }
 
 function cleanup() {
+	# shellcheck disable=SC2317
 	[[ -n "$UNPACK_DIR" ]] && [[ -d "$UNPACK_DIR" ]] && rm -rf "$UNPACK_DIR"
 }
 


### PR DESCRIPTION
See [here](https://github.com/delphix/delphix-platform/pull/450) for more details.