### PR TITLE
DLPX-86540 CIS: IP kernel settings

### DIFF
--- a/files/common/lib/sysctl.d/50-override.conf
+++ b/files/common/lib/sysctl.d/50-override.conf
@@ -111,20 +111,60 @@ fs.leases-enable = 0
 # ICMP Redirects, send routing information to other hosts is not
 # required because this host is not acting as a router.
 #
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+
+#
 # A system with multiple interfaces need net.ipv4.ip_forward
 # to forward the packets, which is not required.
 #
-net.ipv4.conf.all.send_redirects = 0
-net.ipv4.conf.default.send_redirects = 0
 net.ipv4.ip_forward = 0
+
+#
+# Source routing is not required in this host to partially or
+# fully specify the route packets take through a network.
+#
 net.ipv4.conf.all.accept_source_route = 0
 net.ipv4.conf.default.accept_source_route = 0
+
+#
+# ICMP redirect messages are packets that convey routing
+# information and tell your host (acting as a router) to
+# send packets via an alternate path. Not required
+#
 net.ipv4.conf.all.accept_redirects = 0
 net.ipv4.conf.default.accept_redirects = 0
+
+#
+# Secure ICMP redirects are not accepted
+#
 net.ipv4.conf.all.secure_redirects = 0
 net.ipv4.conf.default.secure_redirects = 0
+
+#
+# Ensure suspicious packets are logged, this feature logs
+# packets with un-routable source addresses to the kernel
+# log.
+#
 net.ipv4.conf.all.log_martians = 1
 net.ipv4.conf.default.log_martians = 1
+
+#
+# Enable system to ignore all ICMP echo and timestamp
+# requests to broadcast and multicast addresses.
+#
 net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+#
+# Some routers (and some attackers) will send responses
+# that violate RFC-1122 and attempt to fill up a log file
+# system with many useless error messages.
+#
 net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+#
+# Stop Attackers to use SYN flood attacks to perform a
+# denial of service attacked on a system by sending many
+# SYN packets without completing the three way handshake.
+#
 net.ipv4.tcp_syncookies = 1

--- a/files/common/lib/sysctl.d/50-override.conf
+++ b/files/common/lib/sysctl.d/50-override.conf
@@ -105,3 +105,26 @@ fs.inotify.max_user_watches = 32768
 # entirely here, to avoid the problem.
 #
 fs.leases-enable = 0
+
+#
+# Ubuntu 20.04 OS hardening changes for CIS benchmarking
+# ICMP Redirects, send routing information to other hosts is not
+# required because this host is not acting as a router.
+#
+# A system with multiple interfaces need net.ipv4.ip_forward
+# to forward the packets, which is not required.
+#
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+net.ipv4.ip_forward = 0
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+net.ipv4.tcp_syncookies = 1


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

The kernal IP settings for Ubuntu 20.04 are not compliant to CIS Benchmark.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

`sysctl` settings should be in a modular file under `/etc/sysctl.d/` for Kernal IP 

````
net.ipv4.conf.all.send_redirects = 0
net.ipv4.conf.default.send_redirects = 0
net.ipv4.ip_forward = 0
net.ipv4.conf.all.accept_source_route = 0
net.ipv4.conf.default.accept_source_route = 0
net.ipv4.conf.all.accept_redirects = 0
net.ipv4.conf.default.accept_redirects = 0
net.ipv4.conf.all.secure_redirects = 0
net.ipv4.conf.default.secure_redirects = 0
net.ipv4.conf.all.log_martians = 1
net.ipv4.conf.default.log_martians = 1
net.ipv4.icmp_echo_ignore_broadcasts = 1
net.ipv4.icmp_ignore_bogus_error_responses = 1
net.ipv4.tcp_syncookies = 1
````
</details>


<details>
<summary><h2> Testing Done </h2></summary>

Upon checking in the OS, find the below settings are available to the OS

````
root@ip-10-110-211-219:/export/home/delphix# 
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.all.send_redirects
net.ipv4.conf.all.send_redirects = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.default.send_redirects
net.ipv4.conf.default.send_redirects = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.ip_forward
net.ipv4.ip_forward = 0
net.ipv4.ip_forward_update_priority = 1
net.ipv4.ip_forward_use_pmtu = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.all.accept_source_route
net.ipv4.conf.all.accept_source_route = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.default.accept_source_route
net.ipv4.conf.default.accept_source_route = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.all.accept_redirects
net.ipv4.conf.all.accept_redirects = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.default.accept_redirects
net.ipv4.conf.default.accept_redirects = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.all.secure_redirects
net.ipv4.conf.all.secure_redirects = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.default.secure_redirects
net.ipv4.conf.default.secure_redirects = 0
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.all.log_martians
net.ipv4.conf.all.log_martians = 1
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.conf.default.log_martians
net.ipv4.conf.default.log_martians = 1
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.icmp_echo_ignore_broadcasts
net.ipv4.icmp_echo_ignore_broadcasts = 1
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.icmp_ignore_bogus_error_responses
net.ipv4.icmp_ignore_bogus_error_responses = 1
root@ip-10-110-211-219:/export/home/delphix# sysctl -a | grep net.ipv4.tcp_syncookies
net.ipv4.tcp_syncookies = 1

````
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>
Well, I am not very sure about this because by adding the settings in a file(can see in the review) has made the setting available to the OS but is not added to any file, well opening this review for taking suggestions.

</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
