### PR TITLE
DLPX-87293 Add AIDE to appliance

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -118,6 +118,13 @@ DEPENDS += delphix-build-info,
 DEPENDS += usrmerge,
 
 #
+# These packages help strengthen the security of the appliance by identifying
+# and preventing undesired behaviors.
+#
+DEPENDS += aide, \
+	   aide-common,
+
+#
 # These packages are tools that are intended for human convenience. The
 # product should not rely on them programmatically. They may be updated
 # or replaced without regard for backward compatibility.

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 #
-# Copyright 2018, 2021 Delphix
+# Copyright 2018, 2024 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

For general security hardening, and to comply with the ubuntu CIS benchmark, we should use AIDE (an open source Tripwire alternative) to monitor and report filesystem integrity violations.

<details open>
<summary><h2> Solution </h2></summary>

Add the Debian/Ubuntu specific packages `aide` and `aide-common`. The former provides the basic `aide` utility, while the latter provides wrappers to use AIDE with sensible defaults as well as a curated list of AIDE rules for Debian/Ubuntu.

Notes:
1. `aide` is required by `aide-common`, but we list `aide` explicitly as a dependency to make it clear that this is a full AIDE installation
2. `aide` takes about 20 minutes to run a full filesystem scan, but installing it won't automatically initialize or run it, so this has no performance impact. Configuring AIDE runs will be left for future tasks.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

Running appliance build that will have AIDE installed: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/6558/

- `Commit 2`: `git ab-pre-push`: http://selfservice.jenkins.delphix.com/job/github/job/delphix/job/delphix-platform/job/appliance-build-orchestrator/job/pre-push/391/ ✅ 
</details>