### PR TITLE
Add scripts to enable rpool disk expansion

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -59,9 +59,11 @@ DEPENDS += ansible, \
 	   debootstrap, \
 	   debsums, \
 	   dmidecode, \
+	   gdisk, \
 	   init, \
 	   iproute2, \
 	   iputils-ping, \
+	   jq, \
 	   kbd, \
 	   kmod, \
 	   less, \
@@ -85,7 +87,8 @@ DEPENDS += ansible, \
 	   sudo, \
 	   systemd-container, \
 	   tzdata, \
-	   udev,
+	   udev, \
+	   util-linux,
 
 #
 # The CRA PAM module provides an authentication method for the delphix user.

--- a/files/common/usr/bin/rpool-disk-attach
+++ b/files/common/usr/bin/rpool-disk-attach
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+#
+# Copyright 2023 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+function cleanup() {
+	# shellcheck disable=SC2317
+	([[ -z "$GRUB_DIR" ]] || [[ ! -d "$GRUB_DIR" ]]) && return
+
+	umount "$GRUB_DIR"
+	rm -rf "$GRUB_DIR"
+}
+
+function get_partition_path() {
+	lsblk -p "$1" --json | jq -Mr '.[][]["children"][0]["name"]'
+}
+
+[[ $# -gt 2 ]] && usage "too many arguments specified"
+[[ $# -eq 1 ]] && usage "too few arguments specified"
+
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+
+trap cleanup EXIT
+
+OLD_DISK_PATH="$(readlink -f "$1")"
+NEW_DISK_PATH="$(readlink -f "$2")"
+
+OLD_DISK_PART="$(get_partition_path "$OLD_DISK_PATH")"
+NEW_DISK_PART="$(get_partition_path "$NEW_DISK_PATH")"
+
+GRUB_DIR=$(mktemp -d -p /tmp -t unpack.XXXXXXX)
+
+set -o xtrace
+zpool attach rpool "$OLD_DISK_PART" "$NEW_DISK_PART"
+mount -t zfs "rpool/grub" "$GRUB_DIR"
+grub-install --root-directory="$GRUB_DIR" "$NEW_DISK_PATH"
+grub-mkconfig -o "$GRUB_DIR/boot/grub/grub.cfg"

--- a/files/common/usr/bin/rpool-disk-detach
+++ b/files/common/usr/bin/rpool-disk-detach
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+#
+# Copyright 2023 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+function get_partition_path() {
+	lsblk -p "$1" --json | jq -Mr '.[][]["children"][0]["name"]'
+}
+
+[[ $# -gt 1 ]] && usage "too many arguments specified"
+[[ $# -eq 0 ]] && usage "too few arguments specified"
+
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+
+DISK_PATH="$(readlink -f "$1")"
+DISK_PART="$(get_partition_path "$DISK_PATH")"
+
+set -o xtrace
+zpool detach rpool "$DISK_PART"

--- a/files/common/usr/bin/rpool-disk-format
+++ b/files/common/usr/bin/rpool-disk-format
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+#
+# Copyright 2023 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+[[ $# -gt 1 ]] && usage "too many arguments specified"
+[[ $# -eq 0 ]] && usage "too few arguments specified"
+
+[[ "$EUID" -ne 0 ]] && die "must be run as root"
+
+DISK_PATH="$(readlink -f "$1")"
+
+set -o xtrace
+sgdisk --zap-all "$DISK_PATH"
+sgdisk "$DISK_PATH" --set-alignment=1 --new=2:1m:+1m --typecode=2:EF02
+sgdisk "$DISK_PATH" --new=1:: --typecode=1:8300
+sgdisk "$DISK_PATH" --print


### PR DESCRIPTION
### Problem

Currently, if we need to swap the current rpool disk to a new disk (e.g. perhaps to expand the rpool size), the process for doing this is all manual. Further, the process required properly partitioning the new disk, and installing grub correctly on it, prior to adding it to the pool. Since none of this process is automated, it can be easy to forget how to do it correctly, and even easier to potentially do it incorrectly.

### Solution

This PR attempts to alleviate the solution by adding a few scripts that can be used to accomplish these tasks.

### Example

#### Format
```
$ sudo ./rpool-disk-format /dev/sda
+ sgdisk --zap-all /dev/sda
GPT data structures destroyed! You may now partition the disk using fdisk or
other utilities.
+ sgdisk /dev/sda --set-alignment=1 --new=2:1m:+1m --typecode=2:EF02
Creating new GPT entries in memory.
The operation has completed successfully.
+ sgdisk /dev/sda --new=1:: --typecode=1:8300
The operation has completed successfully.
+ sgdisk /dev/sda --print
Disk /dev/sda: 2147483648 sectors, 1024.0 GiB
Model: Virtual disk
Sector size (logical/physical): 512/512 bytes
Disk identifier (GUID): CB2209E2-F883-440D-ABAE-DA8A5D40996C
Partition table holds up to 128 entries
Main partition table begins at sector 2 and ends at sector 33
First usable sector is 34, last usable sector is 2147483614
Partitions will be aligned on 2048-sector boundaries
Total free space is 2014 sectors (1007.0 KiB)

Number  Start (sector)    End (sector)  Size       Code  Name
   1            4096      2147483614   1024.0 GiB  8300
   2            2048            4095   1024.0 KiB  EF02
```

#### Attach
```
$ sudo ./rpool-disk-attach /dev/sde /dev/sda
+ zpool attach rpool /dev/sde1 /dev/sda1
+ mount -t zfs rpool/grub /tmp/unpack.nlu1JDk
+ grub-install --root-directory=/tmp/unpack.nlu1JDk /dev/sda
Installing for i386-pc platform.
Installation finished. No error reported.
+ grub-mkconfig -o /tmp/unpack.nlu1JDk/boot/grub/grub.cfg
Sourcing file `/etc/default/grub'
Sourcing file `/etc/default/grub.d/init-select.cfg'
Sourcing file `/etc/default/grub.d/kdump-tools.cfg'
Sourcing file `/etc/default/grub.d/override.cfg'
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.15.0-79-dx2023082816-dd7fad44b-generic
Found initrd image: /boot/initrd.img-5.15.0-79-dx2023082816-dd7fad44b-generic
done
+ cleanup
+ [[ -z /tmp/unpack.nlu1JDk ]]
+ [[ ! -d /tmp/unpack.nlu1JDk ]]
+ umount /tmp/unpack.nlu1JDk
+ rm -rf /tmp/unpack.nlu1JDk
```

#### Detach
```
$ sudo ./rpool-disk-detach /dev/sda
+ zpool detach rpool /dev/sda1
```