### PR TITLE
DLPX-87656 Enable SFTP for Internal Variants

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -300,12 +300,18 @@
     #
     - variant is regex("external-.*")
 #
-# Harden the appliance by disabling SFTP.
+# Harden the appliance by disabling SFTP on external variants.
 #
 - replace:
     path: /etc/ssh/sshd_config
     regexp: '^(Subsystem.*sftp.*)'
     replace: '#\1'
+  when:
+    #
+    # Disable sftp on external variants and leave it enabled on internal
+    # variants for developer convenience and to facilitate test automation.
+    #
+    - variant is regex("external-.*")
 
 #
 # Ssh leads to the CLI, not bash, so let's remove all the linuxy shell goodies,


### PR DESCRIPTION
# Problem
- As part of https://github.com/delphix/dlpx-app-gate/pull/1190 of dlpx-app-gate, the file transfer protocol of sshj changed from SCP to SFTP but sftp is disabled on DE so to test SFTP working on DE as part of dxoTest and internal-variants uncomment below line from sshd_config:
Subsystem       sftp    /usr/lib/openssh/sftp-server

# Solution
- Added a condition in the ansible code of commenting above the line, Only comment for the external variants. 

# Testing
- Took ab-pre-push image and tested sftp, sftp is working on the qa-internal image. 