### PR TITLE
DLPX-81199 don't run zfs-mount service within upgrade container

### DIFF
--- a/files/common/lib/systemd/system/zfs-share.service.d/override.conf
+++ b/files/common/lib/systemd/system/zfs-share.service.d/override.conf
@@ -1,0 +1,13 @@
+#
+# During upgrade verification, the root filesystem will be booted as a
+# container using systemd-nspawn. We don't "sandbox" the container, so
+# when zfs-share.service runs, it'll automatically mount all "domain0"
+# mountpoints (or "dcenter" mountpoints for our DCenter systems). These
+# mounts in the container can then impact software running outside of
+# the container; e.g. "zfs destroy" can fail with EBUSY.
+#
+# Thus, to workaround this problem, we explicitly disable this service
+# from running when inside of the container.
+#
+[Unit]
+ConditionVirtualization=!container


### PR DESCRIPTION
This is a continuation of #465, we missed a service in that PR.