### PR TITLE
DLPX-88235 SHA1 deprecated setting for SSH

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -232,7 +232,6 @@
     path: /etc/ssh/sshd_config
     regexp: "^#?{{ item.key }} "
     line: "{{ item.key }} {{ item.value }}"
-  notify: "sshd config changed"
   with_items:
     #
     # Configure SSH to allow PAM "conversations" (interactions with the user).
@@ -251,6 +250,7 @@
     # Configure SSH to exclude the 'ssh-rsa' algorithm from HostKeyAlgorithms
     #
     - { key: "HostKeyAlgorithms", value: "-ssh-rsa*" }
+  notify: "sshd config changed"
 
 #
 # The CRA project mandated a 30 minute timeout for any idle connections.

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -246,9 +246,6 @@
     - { key: "AllowStreamLocalForwarding", value: "no" }
     - { key: "AllowTcpForwarding", value: "no" }
     - { key: "X11Forwarding", value: "no" }
-    #
-    # Configure SSH to exclude the 'ssh-rsa' algorithm from HostKeyAlgorithms
-    #
     - { key: "HostKeyAlgorithms", value: "-ssh-rsa*" }
   notify: "sshd config changed"
 

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -232,6 +232,7 @@
     path: /etc/ssh/sshd_config
     regexp: "^#?{{ item.key }} "
     line: "{{ item.key }} {{ item.value }}"
+  notify: "sshd config changed"
   with_items:
     #
     # Configure SSH to allow PAM "conversations" (interactions with the user).

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -246,6 +246,11 @@
     - { key: "AllowStreamLocalForwarding", value: "no" }
     - { key: "AllowTcpForwarding", value: "no" }
     - { key: "X11Forwarding", value: "no" }
+    #
+    # Qualys scan QID: 38909 SHA1 deprecated setting for SSH
+    # Configure SSH to skip ssh-rsa in HostKeyAlgorithms
+    #
+    - { key: "HostKeyAlgorithms", value: "-ssh-rsa*" }
 
 #
 # The CRA project mandated a 30 minute timeout for any idle connections.

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -247,8 +247,7 @@
     - { key: "AllowTcpForwarding", value: "no" }
     - { key: "X11Forwarding", value: "no" }
     #
-    # Qualys scan QID: 38909 SHA1 deprecated setting for SSH
-    # Configure SSH to skip ssh-rsa in HostKeyAlgorithms
+    # Configure SSH to exclude the 'ssh-rsa' algorithm from HostKeyAlgorithms
     #
     - { key: "HostKeyAlgorithms", value: "-ssh-rsa*" }
 


### PR DESCRIPTION
https://delphix.atlassian.net/browse/DLPX-88235

# Problem
This is related to Qualys reporting a vulnerability QID: 38909, where in ssh-rsa is vulnerable to collision attacks, which are designed to fabricate the same hash value for different input data. each hash is supposedly unique.

# Solution
Adding a setting in sshd_config to not add ssh-rsa in HostKeyAlgorithms. 

# Build
ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7302/

# Manual Testing
Ran ab-pre-push, created a image and validated the `sshd_config` file and able to see the new setting and validated the `sshd -T` to check the `HostKeyAlgorithms` which does not have `ssh-rsa`

_snippet of sshd_config_
```
# Example of overriding settings on a per-user basis
#Match User anoncvs
#	X11Forwarding no
#	AllowTcpForwarding no
#	PermitTTY no
#	ForceCommand cvs server
AllowStreamLocalForwarding no
HostKeyAlgorithms -ssh-rsa*
MACs -hmac-sha1*,umac-64*
root@ip-10-110-251-224:/etc/ssh# 
```

```
root@ip-10-110-251-224:/etc/ssh# sshd -T | grep hostkeyalgorithms
hostkeyalgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ecdsa-sha2-nistp256@openssh.com,ssh-ed25519,sk-ssh-ed25519@openssh.com,rsa-sha2-512,rsa-sha2-256

```

Before the change:
_snippet of sshd_config_
```
# Example of overriding settings on a per-user basis
#Match User anoncvs
#	X11Forwarding no
#	AllowTcpForwarding no
#	PermitTTY no
#	ForceCommand cvs server
PermitRootLogin=yes
AllowStreamLocalForwarding no
MACs -hmac-sha1*,umac-64*
```

```
root@ip-10-110-213-215:/etc/ssh#  sshd -T | grep hostkeyalgorithms
hostkeyalgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ecdsa-sha2-nistp256@openssh.com,ssh-ed25519,sk-ssh-ed25519@openssh.com,rsa-sha2-512,rsa-sha2-256,ssh-rsa
```

Manually tested the upgrade from 16.0 and see the `sshd_config` file has taken the change and `sshd -T` has the changes.