### PR TITLE
DLPX-86535 CIS: restrict access to su command

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -330,6 +330,15 @@
     replace: '#\1'
 
 #
+# Restricting su access to ensure only authorized users in a specific group
+# can elevate privileges to another user, like the root user
+#
+- replace:
+    dest: /etc/pam.d/su
+    regexp: '^#?[\s]*(auth[\s]+required[\s]+pam_wheel\.so.*)$'
+    replace: '\1'
+
+#
 # Prevent sshd from offering weak message authentication codes to clients.
 #
 # The "MACs" configuration parameter in sshd_config takes a list of algorithms

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -330,8 +330,8 @@
     replace: '#\1'
 
 #
-# Restricting su access to ensure only authorized users in a specific group
-# can elevate privileges to another user, like the root user
+# Restrict su access to users that are part of the root group (gid 0).
+# On a Delphix engine, this is restricted to the delphix user.
 #
 - replace:
     dest: /etc/pam.d/su


### PR DESCRIPTION
Problem
======
```
Status of the pam module 'pam_wheel.so' setting in PAM configuration file '/etc/pam.d/ su'

The 'su' (switch user) command in '/etc/pam.d/su' allows a user to run a shell or execute commands 
using a different user/group ID, which also provides the privileges of that user. As there are well known 
privilege escalation risks and a lack of granular logging and auditing while using 'su', this module 
should be configured according to the needs of the business. 
NOTE: A comma-separated 'user list' should be reviewed and approved in the 'wheel statement' 
within the '/etc/group' file, according to the CIS Benchmark, should be completed.

Remediation: # Edit file '/etc/pam.d/su' to add or uncomment the 'pam_wheel.so' statement to 
allow only users which are in the wheel group to execute su according to the business needs 
and organization's security policies. auth <required|requisite> pam_wheel.so

# Example
auth required pam_wheel.so
```

Solution
======

- Updated `/etc/pam.d/su `file to restrict access to su command by uncommenting `auth  required  pam_wheel.so` in the file.
- Validated` sudo su` woks fine with this code change.

 
Testing Done
========
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7619/ - `Successful`

