### PR TITLE
DLPX-87205 CIS: default umask

### DIFF
--- a/files/common/etc/profile.d/set-umask-for-all-users.sh
+++ b/files/common/etc/profile.d/set-umask-for-all-users.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+umask 027

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -680,3 +680,14 @@
       . /etc/bash_completion.d/systemctl
       . /etc/bash_completion.d/zfs
       PATH=$PATH:/opt/delphix/server/bin
+
+#
+# CIS: Set default umask (DLPX-87205)
+# We need to set default umask as 027 in the /etc/bash.bashrc file,
+# so that the same can be applied for all the users on the engine.
+#
+- blockinfile:
+    path: /etc/bash.bashrc
+    block: |
+      # Set default umask value.
+      umask 027


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

<!--
Provide a clear description of the high-level problem you are trying to
solve. The problem statement should be written in terms of a specific
symptom that affects users or the business. The problem statement should
not be written in terms of the solution. If possible, include a minimal
reproducible example (MRE) with steps to reproduce, expected results,
and actual results.
-->
```
(5.76) 4726 Current 'UMASK' setting for the '/etc/bashrc or /etc/bash.bashrc' file

The 'default UMASK permissions' determine what [default] privilege level will be set upon directories and files created by the user. The usual manufacturer default is '022.' If set at this value, when creating a new file, the resulting default permissions will be '644' (666 minus 022, i.e. -rw-r--r--). When creating a new directory, these default permissions will be 755 (drwxr-xr-x), which sets the access level to (rwx r-x r-x): for owner (rwx), group (read/execute), other (read/execute) access on file access. If users are not properly restricted, sensitive system or business information may be improperly disclosed. The most restrictive setting is 077 and your default file permissions would be 600 (-rw-------) and your default directory permissions would be 700 (drwx------), thus becoming (rwx --- ---): for owner (rwx), group (no access), other (no access). Also, as a malicious user could lay the groundwork for a privilege escalation attack by changing the UMASK value in this configuration file, access to this file and its UMASK setting should be restricted appropriately.

Remediation: # Edit file '/etc/bash.bashrc' to configure 'UMASK' setting according to the business needs and organization's security policies.

UMASK <number>

# Example UMASK 027

(5.77) 12884 Status of 'umask' setting in /etc/profile and /etc/profile.d/*.sh files

The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files ( .profile , .bashrc , etc.) in their home directories. Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system. This setting should be configured according to the needs of the business.

Remediation:

Run the following command to verify the 'umask' setting in '/etc/profile and /etc/profile.d/*.sh' files. $sudo grep "umask" /etc/profile /etc/profile.d/*.sh
umask 027

Edit the 'etc/profile and /etc/profile.d/*.sh' file to configure 'umask' setting according to the business needs and organization's security policies.
umask <permissions>

# Example umask 022
```
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

<!--
Provide a clear description of the high-level solution you have chosen.
If there were other possible solutions that you considered and rejected,
mention those along with the corresponding reasoning. Do not describe
implementation details when writing about the solution; these should go
into the implementation section instead.
-->
- Added a file `/etc/profile.d/set-umask-for-all-users.sh` to set umask to `027` and also added the same in `/etc/bash.bashrc` file as well.
- Originally we integrated the changes to set the default umask as 027 on the Delphix engine as part of [DLPX-86533](https://delphix.atlassian.net/browse/DLPX-86533)
- But it was needed to revert the change to unblock masking development and automation work as it was causing permission issues while starting the masking service as the masking user, for reference: https://delphix.slack.com/archives/C03HWSD12/p1690393752112389
- The change was reverted as part of [DLPX-87136](https://delphix.atlassian.net/browse/DLPX-87136)
 
- This change depends upon https://github.com/delphix/dms-core-gate/pull/987 which solves the permission issues for `/opt/delphix/masking`
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

<!--
Provide a clear description of how this change was tested. At minimum
this should include proof that a computer has executed the changed
lines. Ideally this should include an automated test or an explanation
as to why this pull request has no tests.
-->
- `git ab-pre-push`
   - http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7780/ ✅ 
   - http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7812/ ✅ 

- Cloned an engine with the changes and validated that umask is set correctly.
```
$ delphix@ip-10-110-235-32:~$ umask
0027
------------------------------------------------------------------------------

$ delphix@ip-10-110-235-32:~$ cat /etc/bash.bashrc | grep umask
# Set default umask value.
umask 027
------------------------------------------------------------------------------

$ delphix@ip-10-110-235-32:~$ cat /etc/profile.d/set-umask-for-all-users.sh 
#!/bin/sh

umask 027
------------------------------------------------------------------------------

delphix@ip-10-110-235-32:~$ mkdir umask-test
delphix@ip-10-110-235-32:~$ ls -la
total 15
drwxr-xr-x 4 delphix staff    8 Jan 30 16:40 .
drwxr-xr-x 5 root    root     5 Jan 30 12:43 ..
drwxr-x--- 2 delphix staff    2 Jan 30 16:40 umask-test
------------------------------------------------------------------------------

(`Masking dir/files permissions are not updated`)
$ delphix@ip-10-110-235-32:~$ ls -la /opt/delphix/masking/bin/
total 70
drwxr-xr-x  3 root root    16 Jan 30 12:37 .
drwxr-xr-x 31 root root    31 Jan 30 12:37 ..
-rwxr-xr-x  1 root root   162 Jan 30 11:54 cancel_support_bundle_generation_process.sh
-rwxr-xr-x  1 root root   990 Jan 30 11:54 copy_generated_support_bundle.sh
-rwxr-xr-x  1 root root  6423 Jan 30 11:54 generate_container_support_bundle.sh
drwxr-xr-x  2 root root     6 Jan 30 12:37 linux
-rwxr-xr-x  1 root root  2920 Jan 30 11:54 masking-phone-home.sh
-rwxr-xr-x  1 root root 22640 Jan 30 11:54 mountFilesystem
-rwxr-xr-x  1 root root 23879 Jan 30 11:54 redact.py
-rwxr-xr-x  1 root root  6684 Jan 30 11:54 setup_masking_internal.sh
-rwxr-xr-x  1 root root  1551 Jan 30 11:54 setup_masking.sh
-rwxr-xr-x  1 root root   342 Jan 30 11:54 setup_masking_vars.sh
-rwxr-xr-x  1 root root  2466 Jan 30 11:54 setup_recreate_masking_gql.sh
-rwxr-xr-x  1 root root  5866 Jan 30 11:54 start_masking.sh
-rwxr-xr-x  1 root root  1531 Jan 30 11:54 sudo_setup_recreate_masking_gql.sh
-rwxr-xr-x  1 root root  5420 Jan 30 11:54 upgrade_masking.sh
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
