### PR TITLE
DLPX-89345 reserving ports for the iSCSI encryption

### DIFF
--- a/files/common/usr/lib/sysctl.d/30-delphix-ports.conf
+++ b/files/common/usr/lib/sysctl.d/30-delphix-ports.conf
@@ -15,12 +15,17 @@
 #
 
 #
-# Local reserved ports for NFSv3
+# Local reserved ports
 # The persistent setting to back /proc/sys/net/ipv4/ip_local_reserved_ports
 #
+# iSCSI ports:
+# 53260 iSCSI listen for encrypted targets
+# 53261 srv side iSCSI stunnel listen
+#
+# NFS ports:
 # 54043 RPC mountd listen
 # 54044 RPC statd listen
 # 54045 RPC lockd/nlockmgr
 # 54046 srv side tunnel listen
 #
-net.ipv4.ip_local_reserved_ports = 54043-54046
+net.ipv4.ip_local_reserved_ports = 53260-53261,54043-54046


### PR DESCRIPTION
# Problem
- To achieve iSCSI encryption we need 2 ports: 
    - One for iSCSI encrypted target communication
    - One for iSCSI stunnel listening
    
# Solution
- Reserved below 2 ports: 
    - For iSCSI encrypted target communication - 53260
    - One for iSCSI stunnel listening - 53261

# Testing
Manual: 

Result of `cat /proc/sys/net/ipv4/ip_local_reserved_ports:`
<img width="658" alt="Screenshot 2024-01-30 at 10 00 00 AM" src="https://github.com/delphix/delphix-platform/assets/121845071/59107066-fe85-45ab-84e1-3a0be14a0a61">
