### PR TITLE
DLPX-86530 CIS: delphix user lockout after failed login attempts

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -337,6 +337,42 @@
     replace: '\1'
 
 #
+#
+# Lock out the user after an unsuccessful consecutive login attempts.
+#
+- lineinfile:
+    path: /etc/pam.d/common-auth
+    line: "{{ item }}"
+    insertbefore: '^auth\s+\[success=1\s+default=ignore\]\s+pam_unix\.so\s+nullok\s+try_first_pass'
+  with_items:
+    - 'auth    required    pam_tally2.so  audit silent deny=5 unlock_time=900'
+
+#
+#
+# Configuration to enforce account lockout policies.
+#
+- lineinfile:
+    path: /etc/pam.d/common-account
+    line: "{{ item }}"
+    insertafter: EOF
+  with_items:
+    - 'account    required    pam_tally2.so'
+
+
+#
+#
+# Configuration to remember user password history.
+#
+- lineinfile:
+    path: /etc/pam.d/common-password
+    line: "{{ item }}"
+    insertbefore: '^password\s+\[success=1 default=ignore\]\s+pam_unix\.so\s+obscure\s+sha512'
+  with_items:
+    - 'password    required    pam_pwhistory.so remember=5'
+
+
+#
+#
 # Enable SNMP client tools to load MIBs by default.
 #
 - replace:


### PR DESCRIPTION
Background
=========
CIS: delphix user lockout after failed login attempts

JIRA: https://delphix.atlassian.net/browse/DLPX-86530

```
Status of the 'deny' setting for pam_tally2.so module in /etc/pam.d/common-auth file
Located in the /etc/pam.d directory, the 'pam_tally2.so' module allows administrators to manage user login security policy and monitor user login activity. The 'deny' parameter in the 'pam_tally2.so' module sets the number of failed login attempts allowed prior to account lockout. As a malicious user can use brute force attacks to compromise user accounts, account lockout policies mitigate this risk by restricting failed login attempts. The 'deny' parameter in the 'pam_tally2.so' module should be set in accordance with needs of the organization.

Remediation: Edit the /etc/pam.d/common-auth file and add the auth line below:
auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900
```

Solution
======
Updating the pam modules `common-auth and common-account` to enforce `delphix` user lockout policies using `pam_tally2.so` 

Testing Done
======
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10988/



**With 4 unsuccessful login attempts and 5th successful login attempt with `delphix` user -**

<img width="666" alt="image" src="https://github.com/delphix/delphix-platform/assets/118707250/fc646f69-3508-4def-85e1-fcade3aaeef7">





**With 5 unsuccessful login attempts and entering correct password at 6th attempt with `delphix` user -** 

`delphix` user lockout already happened and after unlock time completion connection to engine will be successful with correct password.

<img width="732" alt="image" src="https://github.com/delphix/delphix-platform/assets/118707250/20a32696-692e-4134-b499-fd478359951a">



**Re-login to engine with delphix user after unlock period is over -** 

<img width="810" alt="image" src="https://github.com/delphix/delphix-platform/assets/118707250/388c51b2-32a5-4aba-a939-048fc03b925d">
