### PR TITLE
DLPX-90398 netplan apply run by cloud-init fails on boot in OCI

### DIFF
--- a/files/oci/etc/cloud/cloud.cfg.d/99-delphix-datasource.cfg
+++ b/files/oci/etc/cloud/cloud.cfg.d/99-delphix-datasource.cfg
@@ -1,1 +1,1 @@
-datasource_list: [ OpenStack ]
+datasource_list: [ Oracle ]


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Recent cloud-init upstream changes changed the way a "datasource" is detected. A "datasource" is a cloud-init term that is used to detect and run cloud-specific code. The fact that cloud-init longer detects the correct datasource causes DCoA issues because the SSH keys it relies on are no longer configured on the engine. 
I filed an issue upstream https://github.com/canonical/cloud-init/issues/5091 and was advised that we should consider using the newer Oracle datasource. In this repo, we have hardcoded cloud-init configuration that causes the OpenStack datasource to be used.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

~~Remove this configuration so that cloud-init detects Oracle cloud correctly.~~
Replace it such that the Oracle data source is used based on feedback from upstream maintainers.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

In progress

ab-pre-push -p oci: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8177/
oci-snapshots with these bits: http://selfservice.jenkins.delphix.com/job/delphix-build-and-snapshots/job/oci-snapshots/8/console

Verified datasource detection in the cloud-init logs:
```
2024-03-26 21:49:43,674 - util.py[DEBUG]: Cloud-init v. 23.4.4-0ubuntu0~20.04.1+delphix.2024.03.08.20.10 finished at Tue, 26 Mar 2024 21:49:43 +0000. Datasource DataSourceOracle.  Up 35.76 seconds
```

On internal variants, verified cloud-init configuration and that authorized_keys now contains my SSH key:
```
delphix@pg-oci-cloud-init-1-nic-1:~$ cat /run/cloud-init/cloud.cfg
datasource_list: [ Oracle, None ]

delphix@pg-oci-cloud-init-1-nic-1:~$ cat ~/.ssh/authorized_keys
ssh-rsa AAAAB3
```

On an external variant, verified cloud-init configuration and that authorized_keys is empty:
```
delphix@pg-oci-cloud-init-ext-nic-1:~$ get-appliance-variant
external-standard

delphix@pg-oci-cloud-init-ext-nic-1:~$ cat /run/cloud-init/cloud.cfg
datasource_list: [ Oracle, None ]

$ sudo grep allow_public_ssh_keys /var/log/cloud-init.log
2024-03-26 22:10:59,502 - cc_ssh.py[DEBUG]: Skipping import of publish SSH keys per config setting: allow_public_ssh_keys=False

delphix@pg-oci-cloud-init-ext-nic-1:~$ cat ~/.ssh/authorized_keys
delphix@pg-oci-cloud-init-ext-nic-1:~$
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
