### PR TITLE
DLPX-91082 build VM panics in zap_create_leaf()

### DIFF
--- a/files/common/lib/modprobe.d/10-zfs.conf
+++ b/files/common/lib/modprobe.d/10-zfs.conf
@@ -131,3 +131,9 @@ options zfs zvol_open_timeout_ms=60000
 # and restart the agent if the connection is hung.
 #
 options zfs zfs_deadman_synctime_ms=60000
+
+#
+# We're seeing a panic on the build server with this new feature
+# enabled, thus we disable it here until we can get that fixed.
+#
+options zfs zap_shrink_enabled=0


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Seeing kernel panics due to zap shrinking logic during builds.

</details>

<details open>
<summary><h2> Solution </h2></summary>

Disable that logic via a tunable.

</details>
