### PR TITLE
DLPX-91197 [Backport of DLPX-91177] Valid Logins/Aliases Guessed with SMTP VRFY Command

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -73,6 +73,7 @@ DEPENDS += ansible, \
 	   netbase, \
 	   netplan.io, \
 	   ntp, \
+		 nullmailer, \
 	   open-iscsi, \
 	   openssh-server, \
 	   openssl, \


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

The postfix package is causing us to listen on 25, which is undesirable.

</details>

<details open>
<summary><h2> Solution </h2></summary>

Add the "nullmailer" package to keep that port closed.

</details>
