### PR TITLE
DLPX-91396 All emails generated by specific cron job, are redirected to the user SMTP.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -45,6 +45,13 @@ configure)
 	systemctl disable motd-news.service
 	systemctl disable motd-news.timer
 
+	#
+	# Various tools generate mail on the system, e.g. cron, and we don't
+	# want those to be sent externally via SMTP (or equivalent). Thus,
+	# we disable this service, so that it doesn't send external mails.
+	#
+	systemctl disable nullmailer.service
+
 	systemctl enable auditd.service
 	systemctl enable delphix.target
 	systemctl enable delphix-platform.service

--- a/debian/postinst
+++ b/debian/postinst
@@ -50,7 +50,7 @@ configure)
 	# want those to be sent externally via SMTP (or equivalent). Thus,
 	# we disable this service, so that it doesn't send external mails.
 	#
-	systemctl disable --now nullmailer.service
+	systemctl disable nullmailer.service
 
 	systemctl enable auditd.service
 	systemctl enable delphix.target

--- a/debian/postinst
+++ b/debian/postinst
@@ -50,7 +50,7 @@ configure)
 	# want those to be sent externally via SMTP (or equivalent). Thus,
 	# we disable this service, so that it doesn't send external mails.
 	#
-	systemctl disable nullmailer.service
+	systemctl disable --now nullmailer.service
 
 	systemctl enable auditd.service
 	systemctl enable delphix.target

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -705,12 +705,3 @@
     block: |
       # Set default umask value.
       umask 027
-
-- file:
-    src: /bin/true
-    dest: /usr/lib/nullmailer/true
-    state: link
-
-- copy:
-    dest: "/etc/nullmailer/remotes"
-    content: "localhost true"

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -705,3 +705,12 @@
     block: |
       # Set default umask value.
       umask 027
+
+- file:
+    src: /bin/true
+    dest: /usr/lib/nullmailer/true
+    state: link
+
+- copy:
+    dest: "/etc/nullmailer/remotes"
+    content: "localhost true"

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -705,3 +705,8 @@
     block: |
       # Set default umask value.
       umask 027
+
+- service:
+    name: "nullmailer"
+    state: "stopped"
+  when: not ansible_is_chroot


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Emails generated by "cron" are being sent externally via SMTP.

</details>

<details open>
<summary><h2> Solution </h2></summary>

Disable "nullmailer" service, so it doesn't send email's externally.

</details>
