### PR TITLE
DLPX-91435 [Forward port of DLPX-91396] All emails generated by specific cron job, are redirected to the user SMTP.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -45,6 +45,13 @@ configure)
 	systemctl disable motd-news.service
 	systemctl disable motd-news.timer
 
+	#
+	# Various tools generate mail on the system, e.g. cron, and we don't
+	# want those to be sent externally via SMTP (or equivalent). Thus,
+	# we disable this service, so that it doesn't send external mails.
+	#
+	systemctl disable nullmailer.service
+
 	systemctl enable auditd.service
 	systemctl enable delphix.target
 	systemctl enable delphix-platform.service

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -705,3 +705,8 @@
     block: |
       # Set default umask value.
       umask 027
+
+- service:
+    name: "nullmailer"
+    state: "stopped"
+  when: not ansible_is_chroot


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/delphix-platform/pull/485