### PR TITLE
DLPX-91653 Use default inotify.max_user_watches

### DIFF
--- a/files/common/lib/sysctl.d/50-override.conf
+++ b/files/common/lib/sysctl.d/50-override.conf
@@ -94,12 +94,6 @@ vm.overcommit_memory = 1
 fs.mount-max = 300000
 
 #
-# We've seen cases where we run out of this resource with the default
-# value of 8192, resulting in upgrade failures.
-#
-fs.inotify.max_user_watches = 32768
-
-#
 # We've seen cases where an NFSv4 delegation is revoked by the server,
 # which then results in client IO errors. We disable NFSv4 delegation
 # entirely here, to avoid the problem.


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Customers still occasionally hit the inotify.max_user_watches limit even at the max setting of 32768.  Use default inotify.max_user_watches now that the following Linux change has increased the max_user_watches based on the amount of addressable memory available.

[inotify: Increase default inotify.max_user_watches limit to 1048576 · torvalds/linux@9289012](https://github.com/torvalds/linux/commit/92890123749bafc317bbfacbe0a62ce08d78efb7)
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Remove hard coded max value for `fs.inotify.max_user_watches` in 50-override.conf.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

ab-pre-push
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8954/

Test different instance sizes:

```
david.mendez@dlpxdc:~$ dc list -o size sync-vm-8a5cd044-6619-0
SIZE
T3_LARGE
delphix@ip-10-110-194-224:~$ cat /proc/sys/fs/inotify/max_user_watches 
56783

david.mendez@dlpxdc:~$ dc list -o size,source_group dm-test-aws
SIZE                 SOURCE_GROUP
DE_CERT_R5N_8XLARGE  temp-sync-AWS-image
elphix@ip-10-110-217-97:~$ cat /proc/sys/fs/inotify/max_user_watches 
1048576
```

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
