### PR TITLE
DLPX-86541 CIS: /dev/shm filesystem and mount options

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -706,7 +706,7 @@
       # Set default umask value.
       umask 027
 
-- posix.mount:
+- ansible.posix.mount:
     path: /dev/shm
     src: tmpfs
     fstype: tmpfs

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -706,6 +706,13 @@
       # Set default umask value.
       umask 027
 
+- posix.mount:
+    path: /dev/shm
+    src: tmpfs
+    fstype: tmpfs
+    opts: defaults,noexec,nosuid,nodev
+    state: mounted
+
 - service:
     name: "nullmailer"
     state: "stopped"


### PR DESCRIPTION
- `git-ab-pre-push` is [here](http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/9297/)