### PR TITLE
DLPX-86541 CIS: /dev/shm filesystem and mount options

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -706,6 +706,14 @@
       # Set default umask value.
       umask 027
 
+- name: Mount /dev/shm with noexec,nosuid,nodev
+  ansible.posix.mount:
+    path: /dev/shm
+    src: tmpfs
+    fstype: tmpfs
+    opts: defaults,noexec,nosuid,nodev
+    state: mounted
+
 - service:
     name: "nullmailer"
     state: "stopped"


### PR DESCRIPTION
# Problem

Any user can upload and execute files inside the /dev/shm similar to the /tmp partition. Configuring /dev/shm allows an administrator to set the noexec option on the mount, making /dev/shm useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw.

<img width="834" alt="Screenshot 2024-09-11 at 8 11 59 PM" src="https://github.com/user-attachments/assets/45ceeea4-d46e-40fd-8901-23083d9ea0d5">


# Solution

- For new installations, during installation create a custom partition setup and specify a separate partition for /dev/shm.
- For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate.

# Implementation

- Added below Ansible logic which runs automatically during the initial appliance build to configure it before the first boot. It also executes at first boot and after upgrades
```
- name: Mount /dev/shm with noexec,nosuid,nodev
  ansible.posix.mount:
    path: /dev/shm
    src: tmpfs
    fstype: tmpfs
    opts: defaults,noexec,nosuid,nodev
    state: mounted
```

# Testing

- ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/9304/ - PASSED

### Manual

- Created an instance from the ab-pre-push image and checked the permission -> It has noexec:

<img width="916" alt="Screenshot 2024-09-13 at 7 57 46 PM" src="https://github.com/user-attachments/assets/0874083c-0411-4b2c-aef5-7387305c3686">

- Took v27 DE and did upgrade with ab-pre-push image and checked the permission -> It has noexec, output is same like above.
