### PR TITLE
DLPX-86524 CIS: remove non-existent paths from the default PATH variable

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -720,10 +720,21 @@
   when: not ansible_is_chroot
 
 #
-# Ensure /snap/bin is removed from PATH in /etc/environment
+# Add the correct path to /etc/security/pam_env.conf and remove any invalid
+# paths from /etc/environment to ensure that non-existent paths are not
+# included in the global PATH.
+#
+- lineinfile:
+    path: /etc/security/pam_env.conf
+    state: present
+    regexp: '^\s*PATH\s+DEFAULT='
+    line: 'PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin'
+
+#
+# MIN_UPGRADE_VERSION(28.0.0.0)
+# This can be removed once the minimum upgrade version is 28.0.0.0.
 #
 - lineinfile:
     path: /etc/environment
-    regexp: '^PATH='
-    line: "{{ lookup('file', '/etc/environment') | regex_search('^PATH=.*') | regex_replace(':/snap/bin', '') }}"
-  when: "'/snap/bin' in lookup('file', '/etc/environment')"
+    state: absent
+    regexp: '^\s*PATH\s*='

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -718,3 +718,12 @@
     name: "nullmailer"
     state: "stopped"
   when: not ansible_is_chroot
+
+#
+# Ensure /snap/bin is removed from PATH in /etc/environment
+#
+- lineinfile:
+    path: /etc/environment
+    regexp: '^PATH='
+    line: "{{ lookup('file', '/etc/environment') | regex_search('^PATH=.*') | regex_replace(':/snap/bin', '') }}"
+  when: "'/snap/bin' in lookup('file', '/etc/environment')"


### PR DESCRIPTION
# Problem

The 'global PATH variable' should be appropriately restricted and not contain any non-directory files. Non-directory files in the global PATH present systemic risks to the host of unauthorized access, alteration and deletion of system files and/or data. Also, non-directory files in the global PATH enable privilege escalation by unauthorized users. As there are several well known exploits of the global PATH settings, these should be carefully configured according to the needs of the business.

<img width="716" alt="Screenshot 2024-09-17 at 3 54 09 PM" src="https://github.com/user-attachments/assets/ebd8cbf5-013c-4a3e-a18b-175024176c0e">

- We don't have anything on the below 2 paths:
```
/usr/games
/usr/local/games
```

- Below 2 paths are symbolic links to `/usr/sbin/` and `/usr/bin`:
```
/sbin
/bin
```

# Solution

- For new installations, during installation set the default PATH exactly as needed, without any invalid entries, to ensure that new non-existent directories don't appear in the future.
- For systems that were previously installed, on upgrade set the default PATH exactly as needed, without any invalid entries, to ensure that new non-existent paths don't appear in the future and remove existing PATH with invalid entries from `/etc/environment` 

# Implementation

- Added below Ansible logics which run automatically during the initial appliance build to configure it before the first boot. It also executes at first boot and after upgrades

For setting the default path:
```
- lineinfile:
     path: /etc/security/pam_env.conf
     state: present
     regexp: '^\s*PATH\s+DEFAULT='
     line: 'PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin'
```

For removing existing PATH with invalid entries from `/etc/environment` 
```
- lineinfile:
    path: /etc/environment
    state: absent
    regexp: '^\s*PATH\s*='
```

# Testing

### Manual

- Created an instance from the ab-pre-push image and checked the $PATH output, `/etc/environment output and `/etc/security/pam_env.conf`:

```
root@ip-10-110-251-174:/export/home/delphix# cat /etc/security/pam_env.conf
#
# This is the configuration file for pam_env, a PAM module to load in
# a configurable list of environment variables for a
.
.
.
#LESS		DEFAULT="M q e h15 z23 b80"
#NNTPSERVER	DEFAULT=localhost
#PATH		DEFAULT=${HOME}/bin:/usr/local/bin:/bin\
#:/usr/bin:/usr/local/bin/X11:/usr/bin/X11
#
# silly examples of escaped variables, just to show how they work.
#
#DOLLAR		DEFAULT=\$
#DOLLARDOLLAR	DEFAULT=	OVERRIDE=\$${DOLLAR}
#DOLLARPLUS	DEFAULT=\${REMOTEHOST}${REMOTEHOST}
#ATSIGN		DEFAULT=""	OVERRIDE=\@
PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
root@ip-10-110-251-174:/export/home/delphix# echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
root@ip-10-110-251-174:/export/home/delphix# cat /etc/environment 
JAVA_HOME="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
```


- Took v27 DE and did upgrade with ab-pre-push image and checked $PATH,  `/etc/environment` and `/etc/security/pam_env.conf` - PATH got removed from the `/etc/environment` and $PATH value updated as mentioned in the above scenario. 
