### PR TITLE
DLPX-86528 CIS: journald configuration

### DIFF
--- a/files/common/lib/systemd/journald.conf.d/override.conf
+++ b/files/common/lib/systemd/journald.conf.d/override.conf
@@ -1,4 +1,22 @@
 [Journal]
+#
+# Enable forwarding of journald logs to the syslog service
+# This helps to ensure compatibility with legacy log systems
+# that rely on syslog for centralized log collection.
+#
+ForwardToSyslog=yes
+#
+# Enable compression for journald logs to save disk space.
+# Older log files will be compressed automatically, helping to
+# retain logs longer without using excessive storage.
+#
+Compress=yes
+#
+# Configure journald to persistently keep logs, so that we can inspect
+# them after a reboot has already occurred. This helps debugging, and
+# also can make the collection of support bundles more useful.
+#
+Storage=persistent
 SystemMaxUse=2.5G
 #
 # The platform service will burst a few thousand lines into the logs

--- a/files/common/lib/systemd/journald.conf.d/override.conf
+++ b/files/common/lib/systemd/journald.conf.d/override.conf
@@ -1,10 +1,4 @@
 [Journal]
-#
-# Configure journald to persistently keep logs, so that we can inspect
-# them after a reboot has already occurred. This helps debugging, and
-# also can make the collection of support bundles more useful.
-#
-Storage=persistent
 SystemMaxUse=2.5G
 #
 # The platform service will burst a few thousand lines into the logs

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -738,3 +738,34 @@
     path: /etc/environment
     state: absent
     regexp: '^\s*PATH\s*='
+
+- lineinfile:
+    path: /etc/systemd/journald.conf
+    regexp: "{{ item.regex }}"
+    line: "{{ item.line }}"
+    state: present
+  with_items:
+    #
+    # Enable forwarding of journald logs to the syslog service
+    # This helps to ensure compatibility with legacy log systems
+    # that rely on syslog for centralized log collection.
+    #
+    - { regex: '^#?ForwardToSyslog=', line: 'ForwardToSyslog=yes' }
+    #
+    # Enable compression for journald logs to save disk space.
+    # Older log files will be compressed automatically, helping to
+    # retain logs longer without using excessive storage.
+    #
+    - { regex: '^#?Compress=', line: 'Compress=yes' }
+    #
+    # Configure journald to persistently keep logs on disk, ensuring
+    # logs are available after reboots. This is useful for post-reboot
+    # debugging and for collecting support bundles with log history.
+    #
+    - { regex: '^#?Storage=', line: 'Storage=persistent' }
+
+- name: Reload and restart systemd-journald to apply changes
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted
+    daemon_reload: yes

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -738,34 +738,3 @@
     path: /etc/environment
     state: absent
     regexp: '^\s*PATH\s*='
-
-- lineinfile:
-    path: /etc/systemd/journald.conf
-    regexp: "{{ item.regex }}"
-    line: "{{ item.line }}"
-    state: present
-  with_items:
-    #
-    # Enable forwarding of journald logs to the syslog service
-    # This helps to ensure compatibility with legacy log systems
-    # that rely on syslog for centralized log collection.
-    #
-    - { regex: '^#?ForwardToSyslog=', line: 'ForwardToSyslog=yes' }
-    #
-    # Enable compression for journald logs to save disk space.
-    # Older log files will be compressed automatically, helping to
-    # retain logs longer without using excessive storage.
-    #
-    - { regex: '^#?Compress=', line: 'Compress=yes' }
-    #
-    # Configure journald to persistently keep logs on disk, ensuring
-    # logs are available after reboots. This is useful for post-reboot
-    # debugging and for collecting support bundles with log history.
-    #
-    - { regex: '^#?Storage=', line: 'Storage=persistent' }
-
-- name: Reload and restart systemd-journald to apply changes
-  ansible.builtin.systemd:
-    name: systemd-journald
-    state: restarted
-    daemon_reload: yes


### PR DESCRIPTION
# Problem
- Below 3 journald configuration must be set: 

**1. ForwardToSyslog**
Default: yes
By default, only forwarding to syslog and wall is enabled

Other Options:
**yes:** (default) Forwards logs to a syslog service like rsyslog or syslog-ng if it's running.
**no:** Logs are not forwarded to syslog and remain only within journals.

**2. Compress**
Default: yes
By default, journald compresses older log files to save disk space.

Other Options:
**yes:** (default) Enables compression of rotated journal files.
**no:** Disables compression, keeping logs uncompressed, which may use more disk space.

**3. Storage**
Default: auto
The default auto setting makes journald decide between volatile (in-memory) or persistent (on-disk) storage based on system configuration.
If /var/log/journal/ exists, logs are stored persistently on disk.
If /var/log/journal/ does not exist, logs are stored in memory (volatile) and will be lost on reboot.

Other Options:
**persistent:** Forces logs to be stored on disk in /var/log/journal/. If the directory does not exist, it will attempt to create it.
**volatile:** Stores logs only in memory (/run/log/journal/), which are lost on reboot.
**none:** Disables all log storage; logs will only be available while they remain in the journal buffer.
**auto:** (default) Automatically uses persistent storage if /var/log/journal/ exists, otherwise falls back to volatile storage.

# Solution
- Delphix does not place journald configuration directly in `/etc/systemd/journald.conf` as the CIS benchmark test expects. We place configuration fragments (overrides) in `/lib/systemd/journald.conf.d/override.conf`. In fact, the Storage attribute is already set to persistent in there (see [override.conf](https://github.com/delphix/delphix-platform/blob/develop/files/common/lib/systemd/journald.conf.d/override.conf) ), so add ForwardToSyslog and Compress there.

# NOTE
- #### There is a bug in the CIS test that we use, which causes it to fail even though we set these configurations in `/lib/systemd/journald.conf.d/override.conf.` The test fails because the configurations are not present in `/etc/systemd/journald.conf`. As long as our configuration aligns with the CIS specifications, we are fine. If necessary, we can always work with CIS or Qualys to get their tests fixed.

# Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/9357/ - PASSED

### Manual
- Tested the below thing from ab-pre-push image with this change: 
    - Created new engine and verified all 3 params in `/lib/systemd/journald.conf.d/override.conf`
    - Cloned v26 DE and upgraded to latest one and then checked `/lib/systemd/journald.conf.d/override.conf` - It has all 3 params as expected.

# Cons of this change

- Storage is already persistent so no effect because of that.
- Compress is also the same as default so no effect because of that, we just meet the CIS benchmark.
- ForwardToSyslog is also the same as default so there is no effect because of that, we just meet the CIS benchmark.