### PR TITLE
DLPX-92291 [Backport of APIGW-9611 to 27.0.0.1] Need script to get app version

### DIFF
--- a/files/common/usr/bin/get-packaged-app-version
+++ b/files/common/usr/bin/get-packaged-app-version
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#
 
 set -o errexit
 set -o pipefail

--- a/files/common/usr/bin/get-packaged-app-version
+++ b/files/common/usr/bin/get-packaged-app-version
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2024 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o errexit
+set -o pipefail
+
+function usage() {
+	echo "Usage: $(basename "$0")"
+	echo
+	echo "Display the app version information for the appliance."
+	exit 2
+}
+
+if [[ $# -gt 0 ]]; then
+	echo "No arguments are supported."
+	usage
+fi
+
+output=$(zfs get -Hpo value "com.delphix:packaged-app-version" "$(dirname "$(zfs list -Hpo name /)")")
+if [[ "$output" != "-" ]]; then
+	echo -n "$output"
+fi

--- a/files/common/usr/bin/get-packaged-app-version
+++ b/files/common/usr/bin/get-packaged-app-version
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-#
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
Clean cherry-pick of #492 needed for DCT specific patch release.

Tested by manually including the script on a 27.0.0.1/patch engine with the dlpx-app-gate corresponding backport deployed and verifying the mgmt stack starts.