### PR TITLE
DLPX-86537 CIS: sudoers configuration

### DIFF
--- a/files/common/etc/logrotate.d/sudo-log
+++ b/files/common/etc/logrotate.d/sudo-log
@@ -1,0 +1,10 @@
+#
+# Copyright 2024 Delphix
+#
+/var/log/sudo.log {
+    weekly
+    rotate 4
+    compress
+    missingok
+    notifempty
+}

--- a/files/common/etc/logrotate.d/sudo-log
+++ b/files/common/etc/logrotate.d/sudo-log
@@ -1,6 +1,3 @@
-#
-# Copyright 2024 Delphix
-#
 /var/log/sudo.log {
     weekly
     rotate 4

--- a/files/common/etc/sudoers.d/delphix
+++ b/files/common/etc/sudoers.d/delphix
@@ -1,6 +1,3 @@
-#
-# Copyright 2018, 2024 Delphix
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/files/common/etc/sudoers.d/delphix
+++ b/files/common/etc/sudoers.d/delphix
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Delphix
+# Copyright 2018, 2024 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,3 +15,5 @@
 #
 
 delphix ALL=(ALL) NOPASSWD:ALL
+Defaults use_pty
+Defaults logfile=/var/log/sudo.log

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -738,3 +738,37 @@
     path: /etc/environment
     state: absent
     regexp: '^\s*PATH\s*='
+
+
+#
+# Ensure Defaults use_pty is set in /etc/sudoers
+#
+- lineinfile:
+    path: /etc/sudoers
+    state: present
+    regexp: '^Defaults use_pty'
+    line: 'Defaults use_pty'
+
+#
+# Ensure Defaults logfile is set in /etc/sudoers
+#
+- lineinfile:
+    path: /etc/sudoers
+    state: present
+    regexp: '^Defaults logfile=/var/log/sudo.log'
+    line: 'Defaults logfile=/var/log/sudo.log'
+
+#
+# Create logrotate configuration for sudo.log
+#
+- copy:
+    dest: /etc/logrotate.d/sudo-log
+    content: |
+      /var/log/sudo.log {
+          weekly
+          rotate 4
+          compress
+          missingok
+          notifempty
+      }
+    mode: '0644'

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -738,37 +738,3 @@
     path: /etc/environment
     state: absent
     regexp: '^\s*PATH\s*='
-
-
-#
-# Ensure Defaults use_pty is set in /etc/sudoers
-#
-- lineinfile:
-    path: /etc/sudoers
-    state: present
-    regexp: '^Defaults use_pty'
-    line: 'Defaults use_pty'
-
-#
-# Ensure Defaults logfile is set in /etc/sudoers
-#
-- lineinfile:
-    path: /etc/sudoers
-    state: present
-    regexp: '^Defaults logfile=/var/log/sudo.log'
-    line: 'Defaults logfile=/var/log/sudo.log'
-
-#
-# Create logrotate configuration for sudo.log
-#
-- copy:
-    dest: /etc/logrotate.d/sudo-log
-    content: |
-      /var/log/sudo.log {
-          weekly
-          rotate 4
-          compress
-          missingok
-          notifempty
-      }
-    mode: '0644'


### PR DESCRIPTION
# Problems

- This setting specifies the presence of 'use_pty' setting in /etc/sudoers and /etc/sudoers.d/ file. If set, sudo will run the command in a pseudo-pty. Attackers can run a malicious program using sudo which would fork a background process that remains even when the main program has finished executing. This setting should be configured according to the needs of the business.

- This setting specifies the presence of sudo log file on the system. A sudo log file simplifies auditing of sudo commands. Sudo provides users with temporarily elevated privileges to perform operations. And if it is enabled, creating an audit log of exactly what was run (and who ran it) is essential to reporting. This setting should be configured according to the needs of the business.

# Solutions

- Edit  `/etc/sudoers.d/delphix` and add below 2 lines in it to get logs of sudo commands:
```
Defaults use_pty
Defaults logfile=/var/log/sudo.log
```
- Add new `/etc/logrotate.d/sudo-log` for log rotation.

# Testing
- Ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/9531/ - Passed

### Manual

- Checked the below details on the New machine with this change and upgraded DE: 
    - These logs are not available on normal machines. 
<img width="586" alt="Screenshot 2024-10-04 at 5 11 24 PM" src="https://github.com/user-attachments/assets/9b053ac8-934d-448b-a566-a311a8510e18">



