### PR TITLE
APIGW-10470 Delphix startup screen should be updated for DCT appliances

### DIFF
--- a/files/common/usr/bin/delphix-startup-screen
+++ b/files/common/usr/bin/delphix-startup-screen
@@ -126,12 +126,21 @@ def load_header(stdscr) -> Any:
     Display the header information for the main screen.
     """
     WIN_LEN, WIN_HT = set_common_variables(stdscr)
-    cmd = ['get-appliance-version', '--patch']
-    cp = subprocess.run(cmd,
+
+    cp = subprocess.run('get-packaged-app-version',
                         stdout=subprocess.PIPE,
                         universal_newlines=True,
                         check=True)
-    version: str = cp.stdout
+    version = cp.stdout
+    if not version:
+        # Use the packaged app version when available
+        # fallback to the appliance version
+        cmd = ['get-appliance-version', '--patch']
+        cp = subprocess.run(cmd,
+                            stdout=subprocess.PIPE,
+                            universal_newlines=True,
+                            check=True)
+        version: str = cp.stdout
 
     stdscr.clear()
     stdscr.addstr(1, 2, LOGO + str(version), curses.A_BOLD)
@@ -219,9 +228,11 @@ def get_network_status() -> Tuple[str, str]:
 
     ipaddrs = []
     for interface in interfaces():
-        if interface == "lo":
+        if (interface == "lo" or
+            interface == "docker0" or
+            interface.startswith("br-")):
             continue
-        for link in ifaddresses(interface)[AF_INET]:
+        for link in ifaddresses(interface).get(AF_INET, []):
             ipaddrs.append(link['addr'])
     hostname = os.uname()[1]
     return (hostname, ", ".join(ipaddrs))
@@ -292,8 +303,12 @@ def display_status(stdscr, win):
         statuswin.hline(START, 5, curses.ACS_HLINE, 45)
         for i in strout.split("\n"):
             START += 1
-            statuswin.addstr(START, 2, " " * (width - 3), curses.A_BOLD)
-            statuswin.addstr(START, 5, str(i), curses.A_STANDOUT)
+            try:
+                statuswin.addstr(START, 2, " " * (width - 3), curses.A_BOLD)
+                statuswin.addstr(START, 5, str(i), curses.A_STANDOUT)
+            except curses.error as e:
+                # Probably exceeded available space
+                logging.info(e)
         statuswin.noutrefresh()
 
         curses.doupdate()

--- a/files/common/usr/bin/delphix-startup-screen
+++ b/files/common/usr/bin/delphix-startup-screen
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2020 Delphix
+# Copyright 2020, 2024 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ def load_header(stdscr) -> Any:
                         stdout=subprocess.PIPE,
                         universal_newlines=True,
                         check=True)
-    version = cp.stdout
+    version: str = cp.stdout
     if not version:
         # Use the packaged app version when available
         # fallback to the appliance version
@@ -140,7 +140,7 @@ def load_header(stdscr) -> Any:
                             stdout=subprocess.PIPE,
                             universal_newlines=True,
                             check=True)
-        version: str = cp.stdout
+        version = cp.stdout
 
     stdscr.clear()
     stdscr.addstr(1, 2, LOGO + str(version), curses.A_BOLD)
@@ -228,9 +228,8 @@ def get_network_status() -> Tuple[str, str]:
 
     ipaddrs = []
     for interface in interfaces():
-        if (interface == "lo" or
-            interface == "docker0" or
-            interface.startswith("br-")):
+        if (interface == "lo" or interface == "docker0" or
+                interface.startswith("br-")):
             continue
         for link in ifaddresses(interface).get(AF_INET, []):
             ipaddrs.append(link['addr'])
@@ -238,7 +237,7 @@ def get_network_status() -> Tuple[str, str]:
     return (hostname, ", ".join(ipaddrs))
 
 
-# pylint: disable-msg=too-many-locals
+# pylint: disable-msg=too-many-locals, too-many-statements
 def display_status(stdscr, win):
     """
     Main display and input function. This function will display


### PR DESCRIPTION
In this PR, we are updating the delphix-startup-screen to work for DCT appliances by making the following changes:

First, we are displaying the packaged-app-version (i.e DCT version) instead of appliance version when it is available.

Then, we are avoiding an exception for network intefaces without address (using python `get` instead of `[]`).

We are hiding the DCT appliance network interfaces (docker0 and docker bridges). This is currently done by name matching, if anyone knows of a better way to identify them that would be great.

Finally, it appears that the list of systemd services now may exceed the available vertical space. While we might want to redesign the screen, or identify which services are critical or not to be visible, I've implemented a much simpler fix by catching the exception and simply moving on (so for DCT appliances the state of the last service, in the order returned by the `systemctl show` command, is missing).



<summary><h2> Testing Done </h2></summary>
A dcol2 DCT appliance (note the DCT version, long list of services, and only the external IP address is visible)

![image](https://github.com/user-attachments/assets/dd4e03aa-79c2-4ef5-aa7a-d94dc1c27e65)

A dcol2 standard engine
![image](https://github.com/user-attachments/assets/a0159b7f-e18c-49c3-9688-f9933c76caaa)


