### PR TITLE
DLPX-93328 LTS upgrade: delphix-platform - Replace ntp with ntpsec as part of DLPX-93325

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -72,8 +72,8 @@ DEPENDS += ansible, \
 	   net-tools, \
 	   netbase, \
 	   netplan.io, \
-	   ntp, \
-		 nullmailer, \
+	   ntpsec, \
+	   nullmailer, \
 	   open-iscsi, \
 	   openssh-server, \
 	   openssl, \


### PR DESCRIPTION
Associated change of https://github.com/delphix/dlpx-app-gate/pull/2845