### PR TITLE
DLPX-93639 LTS 24.04: Upgrade fails due to drgn conflict with upstream python3-drgn package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -129,7 +129,7 @@ DEPENDS += aptitude, \
 	   crash-python, \
 	   delphix-rust, \
 	   dnsutils, \
-	   python3-drgn, \
+	   drgn, \
 	   emacs-nox, \
 	   ethtool, \
 	   gdb, \


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrade from 20.04 to 24.04 fails due to package name difference of our internal version of the "drgn" package, and ubuntu's package.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution here, is to keep using our internal "drgn" package, rather than ubuntu's. This is dependent on: https://github.com/delphix/linux-pkg/pull/339
</details>
