### PR TITLE
DLPX-93685 LTS 24.04: Upgrade fails due to libkdumpfile conflict with upstream libkdumpfile10 package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -140,7 +140,7 @@ DEPENDS += aptitude, \
 	   jq, \
 	   kdump-tools, \
 	   ldap-utils, \
-	   libkdumpfile10, \
+	   libkdumpfile, \
 	   linux-tools-common, \
 	   lsof, \
 	   man-db, \

--- a/debian/rules
+++ b/debian/rules
@@ -140,7 +140,6 @@ DEPENDS += aptitude, \
 	   jq, \
 	   kdump-tools, \
 	   ldap-utils, \
-	   libkdumpfile, \
 	   linux-tools-common, \
 	   lsof, \
 	   man-db, \


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrade from 20.04 to 24.04 fails due to package name difference of our internal version of the "libkdumpfile" package, and ubuntu's package.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution here, is to keep using our internal "libkdumpfile" package, rather than ubuntu's.
</details>
