### PR TITLE
DLPX-93706 LTS 24.04: unable to disable systemd services during upgrade

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -17,6 +17,13 @@
 
 case $1 in
 configure)
+	#
+	# We've seen cases where upgrade bumps the systemd version drastically
+	# enough, such that we need to restart the process in order for systemctl
+	# commands to work properly. Thus, we restart systemd here.
+	#
+	systemctl daemon-reexec
+
 	systemctl disable apt-daily.service
 	systemctl disable apt-daily.timer
 

--- a/debian/rules
+++ b/debian/rules
@@ -84,6 +84,7 @@ DEPENDS += ansible, \
 	   rng-tools, \
 	   rsyslog, \
 	   sudo, \
+	   systemd, \
 	   systemd-container, \
 	   systemd-resolved, \
 	   tzdata, \


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrade is failing, due to systemctl commands failing.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken in this change, is to call "daemon-reexec" via the platform package's postinst script.
</details>
