### PR TITLE
DLPX-93729 LTS 24.04: unable to upgrade emacs-nox package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -130,7 +130,6 @@ DEPENDS += aptitude, \
 	   delphix-rust, \
 	   dnsutils, \
 	   drgn, \
-	   emacs-nox, \
 	   ethtool, \
 	   gdb, \
 	   htop, \


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrade is failing due to errors when running emacs post-install hooks.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken here is to remove the emacs package(s) from the appliance.
</details>
