### PR TITLE
DLPX-93731 LTS 24.04: delphix-platform package hook fails due to delphix.target being masked

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -53,11 +53,13 @@ configure)
 	systemctl disable nullmailer.service
 
 	systemctl enable auditd.service
-	systemctl enable delphix.target
 	systemctl enable delphix-platform.service
 	systemctl enable delphix-rpool-upgrade.service
 	systemctl enable systemd-networkd.service
 	systemctl enable iscsi-name-init.service
+
+	systemctl unmask delphix.target
+	systemctl enable delphix.target
 
 	if ! id -u postgres >/dev/null; then
 		# When installing postgres, a postgres user is created unless it


### PR DESCRIPTION
it's unclear what is masking `delphix.target`, but since `systemctl unmask` is idempotent (if it's already unmasked, it won't throw an error), I'm opting to explicitly unmask it to unblock testing.