### PR TITLE
DLPX-93749 LTS 24.04: sshd service fails to restart via virtualization's postinst hook

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/handlers/main.yaml
@@ -27,7 +27,7 @@
   when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot
 
 - systemd:
-    name: sshd
+    name: ssh
     state: reloaded
   listen: "sshd config changed"
   when: ansible_virtualization_type != "systemd-nspawn" and not ansible_is_chroot


### PR DESCRIPTION
the sshd service doesn't exist, it's named ssh now.