### PR TITLE
DLPX-93748 LTS 24.04: various services masked, causing enable to fail during package installation

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -52,8 +52,13 @@ configure)
 	#
 	systemctl disable nullmailer.service
 
+	systemctl unmask auditd.service
 	systemctl enable auditd.service
+
+	systemctl unmask systemd-networkd.service
 	systemctl enable systemd-networkd.service
+
+	systemctl unmask iscsi-name-init.service
 	systemctl enable iscsi-name-init.service
 
 	systemctl unmask delphix-platform.service


### PR DESCRIPTION
Unsure what is masking these services, but this should unblock us for now; we can revisit this later.
