### PR TITLE
DLPX-93823 cloud-init configuration contains module names that are no longer correct

### DIFF
--- a/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
+++ b/files/common/etc/cloud/cloud.cfg.d/91-delphix-platform.cfg
@@ -48,11 +48,14 @@ apt:
 
 #
 # By default, ignore ssh keys passed from the cloud management console.
-# Also, discard any user data to prevent tampering with the default
-# Delphix configuration. Note that those configurations are currently
-# only available on Delphix's version of cloud-init.
 #
 allow_public_ssh_keys: false
+
+#
+# Discard any user data (cloud-init configuration passed to the instance via
+# cloud-specific mechanisms) to prevent tampering with the default Delphix
+# configuration.
+#
 allow_userdata: false
 
 #
@@ -116,32 +119,27 @@ datasource_list:
 #
 
 cloud_init_modules:
- - migrator
  - seed_random
  - bootcmd
- - write-files
+ - write_files
  - update_etc_hosts
  - ssh
 
 cloud_config_modules:
- - wireguard
- - ubuntu_autoinstall
- - ssh-import-id
+ - ssh_import_id
  - keyboard
  - locale
- - grub-dpkg
- - apt-pipelining
- - apt-configure
+ - grub_dpkg
+ - apt_configure
  - ntp
  - runcmd
 
 cloud_final_modules:
- - package-update-upgrade-install
- - write-files-deferred
- - scripts-vendor
- - scripts-per-once
- - scripts-per-boot
- - scripts-per-instance
- - scripts-user
- - install-hotplug
- - final-message
+ - write_files_deferred
+ - scripts_per_once
+ - scripts_per_boot
+ - scripts_per_instance
+ - scripts_user
+ - install_hotplug
+ - final_message
+ - power_state_change


### PR DESCRIPTION
A few years ago, a cloud-init developer decided to rename all of the cloud-init
modules that had embedded hyphens in their name to replace those hyphens with
underscores. Our custom cloud-init configuration was never adjusted to account
for this.

This is also a good opportunity to verify what all of these modules do and validate
the list. If you're curious to know what each of these is supposed to do, they're
all documented at https://github.com/delphix/cloud-init/tree/develop/doc/module-docs (or https://docs.cloud-init.io/en/latest/reference/modules.html if you want a more user-friendly way to consume that).

Note that because we already configure cloud-init with `allow_userdata: false`, none of these
modules have access to any externally provided user data, which eliminates the
possibility of a cloud or hypervisor admin tampering with the Delphix configuration.

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10695/
