### PR TITLE
DLPX-93961 LTS 24.04: getty services failed due to missing python3-netifaces

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -81,6 +81,7 @@ DEPENDS += ansible, \
 	   policykit-1, \
 	   procps, \
 	   python3, \
+	   python3-netifaces, \
 	   rng-tools, \
 	   rsyslog, \
 	   sudo, \


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

The getty services can’t come up because the ExecStart /sbin/agetty /usr/bin/delphix-startup-screen command failed due to missing python3-netifaces module
```
delphix@ip-10-110-199-244:~$ systemctl status getty@tty1.service
× getty@tty1.service - Getty on tty1
     Loaded: loaded (/usr/lib/systemd/system/getty@.service; enabled; preset: enabled)
    Drop-In: /usr/lib/systemd/system/getty@tty1.service.d
             └─override.conf
     Active: failed (Result: start-limit-hit) since Wed 2025-04-16 15:26:36 UTC; 23min ago
   Duration: 350ms
       Docs: man:agetty(8)
             man:systemd-getty-generator(8)
             https://0pointer.de/blog/projects/serial-console.html
    Process: 11757 ExecStart=/sbin/agetty -n -l /usr/bin/delphix-startup-screen --noclear tty1 $TERM (code=exited, status=1/FAILURE)
   Main PID: 11757 (code=exited, status=1/FAILURE)
        CPU: 253ms   delphix@ip-10-110-199-244:~$ sudo apt update/sbin/agetty -n -l /usr/bin/delphix-startup-screen --noclear tty1 $TERM^C

delphix@ip-10-110-199-244:~$ /usr/bin/delphix-startup-screen
Traceback (most recent call last):
  File "/usr/bin/delphix-startup-screen", line 31, in <module>
    from netifaces import interfaces, ifaddresses, AF_INET
ModuleNotFoundError: No module named 'netifaces'
delphix@ip-10-110-199-244:~$ 
```
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

The solution is to include python3-netifaces into the appliance.

Below steps show services can start successfully after python3-netifaces installation. 
```
delphix@ip-10-110-199-244:~$ sudo apt install python3-netifaces
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  python3-netifaces
0 upgraded, 1 newly installed, 0 to remove and 11 not upgraded.
Need to get 18.1 kB of archives.
After this operation, 58.4 kB of additional disk space will be used.
Get:1 http://us-west-2.ec2.archive.ubuntu.com/ubuntu noble/main amd64 python3-netifaces amd64 0.11.0-2build3 [18.1 kB]
Fetched 18.1 kB in 0s (47.0 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package python3-netifaces:amd64.
(Reading database ... 208222 files and directories currently installed.)
Preparing to unpack .../python3-netifaces_0.11.0-2build3_amd64.deb ...
Unpacking python3-netifaces:amd64 (0.11.0-2build3) ...
Setting up python3-netifaces:amd64 (0.11.0-2build3) ...

delphix@ip-10-110-199-244:~$ sudo systemctl restart getty@tty1.service
delphix@ip-10-110-199-244:~$ sudo systemctl status getty@tty1.service
● getty@tty1.service - Getty on tty1
     Loaded: loaded (/usr/lib/systemd/system/getty@.service; enabled; preset: enabled)
    Drop-In: /usr/lib/systemd/system/getty@tty1.service.d
             └─override.conf
     Active: active (running) since Wed 2025-04-16 15:56:38 UTC; 6s ago
       Docs: man:agetty(8)
             man:systemd-getty-generator(8)
             https://0pointer.de/blog/projects/serial-console.html
   Main PID: 15478 (delphix-startup)
      Tasks: 1 (limit: 8756)
     Memory: 7.5M (peak: 9.7M)
        CPU: 814ms
     CGroup: /system.slice/system-getty.slice/getty@tty1.service
             └─15478 /usr/bin/python3 /usr/bin/delphix-startup-screen

delphix@ip-10-110-199-244:~$ sudo systemctl restart serial-getty@ttyS0.service
delphix@ip-10-110-199-244:~$ sudo systemctl status serial-getty@ttyS0.service
● serial-getty@ttyS0.service - Serial Getty on ttyS0
     Loaded: loaded (/usr/lib/systemd/system/serial-getty@.service; enabled-runtime; preset: enabled)
    Drop-In: /usr/lib/systemd/system/serial-getty@ttyS0.service.d
             └─override.conf
     Active: active (running) since Wed 2025-04-16 15:57:31 UTC; 7s ago
       Docs: man:agetty(8)
             man:systemd-getty-generator(8)
             https://0pointer.de/blog/projects/serial-console.html
   Main PID: 15641 (delphix-startup)
      Tasks: 1 (limit: 8756)
     Memory: 7.2M (peak: 9.8M)
        CPU: 229ms
     CGroup: /system.slice/system-serial\x2dgetty.slice/serial-getty@ttyS0.service
             └─15641 /usr/bin/python3 /usr/bin/delphix-startup-screen
```

And still good after a reboot
```
Apr 16 15:57:31 ip-10-110-199-244 systemd[1]: Started serial-getty@ttyS0.service - Serial Getty on ttyS0.   delphix@ip-10-110-199-244:~$ systemctl status | head
● ip-10-110-199-244
    State: running
    Units: 379 loaded (incl. loaded aliases)
     Jobs: 0 queued
   Failed: 0 units
    Since: Wed 2025-04-16 15:58:20 UTC; 14min ago
  systemd: 255.4-1ubuntu8.6
   CGroup: /
           ├─init.scope
           │ └─1 /sbin/init
```

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Built linux-packages:
https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/build-package/job/delphix-platform/job/pre-push/84/
https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/combine-packages/job/pre-push/134/

Then built appliance and verified delphix startup screen is correctly displayed 

![Screenshot 2025-04-17 at 09 22 08](https://github.com/user-attachments/assets/f1df85c6-88e0-403c-b40c-a270ec322acd)


</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
