### PR TITLE
DLPX-94126 LTS 24.04: Engine|Challenge/Response prompt not occurring for external DCoA os-upgrade variants

### DIFF
--- a/files/azure/etc/ssh/sshd_config.d/0-delphix-azure.conf
+++ b/files/azure/etc/ssh/sshd_config.d/0-delphix-azure.conf
@@ -1,0 +1,10 @@
+#
+# The 'ClientAliveInterval' setting determines the amount of time (in seconds)
+# the sshd server will wait to receive data from the client before sending a
+# request for response.
+#
+# The Azure marketplace does not allow a value greater than 3 minutes. So, when
+# running on Azure, we use 3 minutes.
+#
+ClientAliveCountMax 0
+ClientAliveInterval 180

--- a/files/common/etc/ssh/sshd_config.d/9-delphix.conf
+++ b/files/common/etc/ssh/sshd_config.d/9-delphix.conf
@@ -32,3 +32,4 @@ LoginGraceTime 60
 MaxAuthTries 4
 MaxStartups 10:30:60
 PermitRootLogin no
+PrintLastLog no

--- a/files/common/etc/ssh/sshd_config.d/9-delphix.conf
+++ b/files/common/etc/ssh/sshd_config.d/9-delphix.conf
@@ -1,0 +1,34 @@
+#
+# Configure SSH to allow PAM "conversations" (interactions with the user).
+#
+ChallengeResponseAuthentication yes
+KbdInteractiveAuthentication yes
+UsePam yes
+
+#
+# Harden the appliance by disabling ssh-agent(1), tcp, UNIX domain, and X11
+# forwarding. Note that this doesn't improve security unless users are also
+# denied shell access.
+#
+AllowAgentForwarding no
+AllowStreamLocalForwarding no
+AllowTcpForwarding no
+X11Forwarding no
+
+Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+MACs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512
+HostKeyAlgorithms -ssh-rsa*
+
+#
+# The 'ClientAliveInterval' setting determines the amount of time (in seconds)
+# the sshd server will wait to receive data from the client before sending a
+# request for response.
+#
+ClientAliveCountMax 3
+ClientAliveInterval 300
+
+LoginGraceTime 60
+MaxAuthTries 4
+MaxStartups 10:30:60
+PermitRootLogin no

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -232,56 +232,6 @@
     - 'delphix'
     - 'root'
 
-#
-# The 'ClientAliveInterval' setting determines the amount of time
-# (in seconds) the sshd server will wait to receive data from the
-# client before sending a request for response.
-#
-- set_fact:
-    ssh_client_alive_interval: "300"
-    ssh_client_alive_count_max: "3"
-
-#
-# With that said (see comment above), the Azure marketplace does not
-# allow a value greater than 3 minutes. So, when running on Azure, we
-# use 3 minutes.
-#
-- set_fact:
-    ssh_client_alive_interval: "180"
-    ssh_client_alive_count_max: "0"
-  when:
-    - platform == "azure"
-
-- lineinfile:
-    path: /etc/ssh/sshd_config
-    regexp: "^#?{{ item.key }} "
-    line: "{{ item.key }} {{ item.value }}"
-  with_items:
-    #
-    # Configure SSH to allow PAM "conversations" (interactions with the user).
-    #
-    - { key: "ChallengeResponseAuthentication", value: "yes" }
-    #
-    # Harden the appliance by disabling ssh-agent(1), tcp, UNIX domain, and
-    # X11 forwarding. Note that this doesn't improve security unless users are
-    # also denied shell access.
-    #
-    - { key: "AllowAgentForwarding", value: "no" }
-    - { key: "AllowStreamLocalForwarding", value: "no" }
-    - { key: "AllowTcpForwarding", value: "no" }
-    - { key: "Ciphers", value: "chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com" }
-    - { key: "ClientAliveCountMax", value: "{{ ssh_client_alive_count_max }}" }
-    - { key: "ClientAliveInterval", value: "{{ ssh_client_alive_interval }}" }
-    - { key: "HostKeyAlgorithms", value: "-ssh-rsa*" }
-    - { key: "KexAlgorithms", value: "curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256"}
-    - { key: "LoginGraceTime", value: "60"}
-    - { key: "MACs", value: "umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512"}
-    - { key: "MaxAuthTries", value: "4" }
-    - { key: "MaxStartups", value: "10:30:60"}
-    - { key: "PermitRootLogin", value: "no" }
-    - { key: "X11Forwarding", value: "no" }
-  notify: "sshd config changed"
-
 - blockinfile:
     path: /etc/profile
     insertafter: EOF
@@ -318,10 +268,6 @@
 # like last-login, "welcome to ubuntu", and help messages. This makes linux and
 # illumos look the same, too.
 #
-- replace:
-    dest: /etc/ssh/sshd_config
-    regexp: '^#?[\s]*PrintLastLog.*$'
-    replace: 'PrintLastLog no'
 - replace:
     dest: /etc/pam.d/sshd
     regexp: '^(session[\s]+optional[\s]+pam_motd\.so.*)$'


### PR DESCRIPTION
For our PAM challenge_response module to work, we need both
`KbdInteractiveAuthentication` and `ChallengeResponseAuthentication` to be set
to `yes`, along with `UsePam`. We never set `KbdInteractiveAuthentication`
before, and its default value changed from `yes` to `no` in 24.04. We need to
epxlicitly set it to `yes` as a result.

Furthermore, sshd now supports configuration overrides via
`/etc/ssh/sshd_config.d/` files, so we should start delivering those as plain
files where possible instead of running ansible logic.

# Testing
I manually tested that this configuration file works, and that when CRA is enabled, this configuration file results in proper CRA prompts from our PAM module.

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/github/job/delphix/job/delphix-platform/job/appliance-build-orchestrator/job/pre-push/634/

I deployed a VM from the ab-pre-push run and verify that all of the correct options are set, as well as test CRA:

```
~ ❯ ssh delphix@seb-2404-sshd.dlpxdc.co                                                                                                                                                 6s
(delphix@seb-2404-sshd.dlpxdc.co) Engine|Challenge: ec25e610-8773-1ddf-58d9-7e9c4108f4b0|35404815
Response:

An empty response was entered. Please try again with a valid response. If the
Delphix Engine is not registered, register it at

    https://register.delphix.com/

using the registration code below:
OTk5OS4w*NFQpwv994wXblM8K6QN5zhJEJG6skOOZC2u1ipVcKLsM5nDgM/43vSAUl+yI4K1BzD92H7q
Ig1Ex8+6+Ag7YYx2h/4Vj1sxq0f+aopoc58fgSt0yL98zaZIk47JFHWsYNoHjOqQYtQ8ELMucLiJugMt
aveMcIlSd02V9p2dvBO5RGQxMZn9SR98tAZp8/xbDddrIAG3CNn13HKDtJpSFVvYQd9coVFyJ3vXtfCc
qaSNuZM+tlOF8+O95Hec/zM9xZrhfoB5aldIAsRSTIOKTD5V9XL1fkp1LrXMNf38fNpLBLAEK7sU1mep
YXIdg1W15nbxRjzpaOR+HHkiuTzTzxNAJxXrJhVK2M16Lx7NUIIcGuAEafEAyl3YFN/BywoB1GL8mYrE
H7xT7cyvLesN5m2x7EjBRGr3+yqvG3SZIlCNLfGd5syUZghGbM/rLZhh3DDpCWAUciOyPn1hFMC1q3IG
q3eHvvaZOWSnZ0Esq1ChO38vKBABZoMD5Y1dNb+oQbQejsTLh/ukSyLw5lzE1rRZvxNttZbR3sm1vLSo
9DHe7+yT7UlKHPzIx3E4sbvnDRSxdpErvP+n0ZJk4tj8xcsCoilE8kFD0JklgsRCLUyTiX47e1+70Wxf
BOi28AXiBCJXDtjdqrbFOslSpXpD1oYx4Wqjmu7nkb7JhvYu+DZA=|ec25e610-8773-1ddf-58d9-7e
9c4108f4b0
(delphix@seb-2404-sshd.dlpxdc.co) Engine|Challenge: ec25e610-8773-1ddf-58d9-7e9c4108f4b0|27761461
Response:
delphix@ip-10-110-228-120:~$
```
