### PR TITLE
DLPX-94300 vmtoolsd conf file not updated due to error in ansible file

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -605,7 +605,7 @@
       # Set to true to disable the servicediscovery plugin.
       disabled=true
   when:
-    - platform == "vmware"
+    - platform == "esx"
   notify: "vmware-tools config changed"
 
 #


### PR DESCRIPTION
The platform name for ESX is not "vmware", but "esx". As such, ansible tasks that are conditionally applied on ESX need to have the correct platform conditional.

### Testing

I applied this on dcol1 and dcol2 and restarted the delphix-platform service. Both applied the configuration successfully.

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/github/job/delphix/job/delphix-platform/job/appliance-build-orchestrator/job/pre-push/645/