### PR TITLE
DLPX-94415 crash dump is generated by "dracut-install" when upgrading from 2025.3.0.1 to 2025.4.0.0

### DIFF
--- a/files/common/lib/systemd/system/kdump-tools.service.d/override.conf
+++ b/files/common/lib/systemd/system/kdump-tools.service.d/override.conf
@@ -1,3 +1,2 @@
 [Unit]
-Requires=local-fs.target
-After=local-fs.target
+DefaultDependencies=yes


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Even after commit 289dd7956ea673e3fd23602097176790ff254348, we're still seeing crashes via the `kdump-tools` service; e.g.

```
$ sudo journalctl -u kdump-tools
...
Jun 16 21:45:56 ip-10-110-232-221 kdump-tools[967]: dracut-install: ERROR: 'cp --reflink=auto --sparse=auto --preserve=mode,xattr,timestamps,ownership -fL /lib/modules/6.8.0-1029-dx2025052218-084078fd5-aws/kernel/dr>
Jun 16 21:45:56 ip-10-110-232-221 kdump-tools[648]: Segmentation fault (core dumped)
...
```

</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken here, is to add the `DefaultDependencies=yes` directive for the service, which was removed in Ubuntu 24.04. It's not clear if this is sufficient, but should be worth a try. Testing the prior commit 289dd7956ea673e3fd23602097176790ff254348 clearly wasn't sufficient, so I'm unsure how to verify this without landing, and seeing if it reproduces again, or not.
</details>


<details>
<summary><h2> Testing Done </h2></summary>
Applied this change, and verified the service dependencies changed.

- Before this change:
```
$ sudo systemctl list-dependencies kdump-tools
kdump-tools.service
● ├─system.slice
● └─local-fs.target
●   ├─export-home.mount
●   ├─systemd-remount-fs.service
●   ├─var-crash.mount
●   ├─var-delphix.mount
●   └─var-log.mount
```

- After this change:
```
$ sudo systemctl list-dependencies kdump-tools
kdump-tools.service
● ├─system.slice
● └─sysinit.target
●   ├─dev-hugepages.mount
●   ├─dev-mqueue.mount
●   ├─keyboard-setup.service
●   ├─kmod-static-nodes.service
○   ├─ldconfig.service
○   ├─open-iscsi.service
●   ├─proc-sys-fs-binfmt_misc.automount
●   ├─setvtrgb.service
●   ├─sys-fs-fuse-connections.mount
●   ├─sys-kernel-config.mount
●   ├─sys-kernel-debug.mount
●   ├─sys-kernel-tracing.mount
●   ├─systemd-ask-password-console.path
●   ├─systemd-binfmt.service
○   ├─systemd-boot-random-seed.service
○   ├─systemd-firstboot.service
○   ├─systemd-hwdb-update.service
○   ├─systemd-journal-catalog-update.service
●   ├─systemd-journal-flush.service
●   ├─systemd-journald.service
○   ├─systemd-machine-id-commit.service
●   ├─systemd-modules-load.service
●   ├─systemd-network-generator.service
○   ├─systemd-pcrmachine.service
○   ├─systemd-pcrphase-sysinit.service
○   ├─systemd-pcrphase.service
○   ├─systemd-pstore.service
●   ├─systemd-random-seed.service
○   ├─systemd-repart.service
●   ├─systemd-resolved.service
●   ├─systemd-sysctl.service
○   ├─systemd-sysusers.service
●   ├─systemd-tmpfiles-setup-dev-early.service
●   ├─systemd-tmpfiles-setup-dev.service
●   ├─systemd-tmpfiles-setup.service
○   ├─systemd-tpm2-setup-early.service
○   ├─systemd-tpm2-setup.service
●   ├─systemd-udev-trigger.service
●   ├─systemd-udevd.service
○   ├─systemd-update-done.service
●   ├─systemd-update-utmp.service
●   ├─cryptsetup.target
●   ├─integritysetup.target
●   ├─local-fs.target
●   │ ├─export-home.mount
●   │ ├─systemd-remount-fs.service
●   │ ├─var-crash.mount
●   │ ├─var-delphix.mount
●   │ └─var-log.mount
●   ├─swap.target
●   └─veritysetup.target
```

</details>
