### PR TITLE
DLPX-94702 kdump cannot find valid symlinks

### DIFF
--- a/files/common/etc/systemd/system/kdump-tools.service
+++ b/files/common/etc/systemd/system/kdump-tools.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kernel crash dump capture service
+
+[Service]
+Type=oneshot
+StandardOutput=journal+console
+EnvironmentFile=/etc/default/kdump-tools
+ExecStartPre=-/usr/share/kdump-tools/kdump_mem_estimator
+ExecStart=/etc/init.d/kdump-tools start
+ExecStop=/etc/init.d/kdump-tools stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=basic.target

--- a/files/common/lib/systemd/system/kdump-tools.service.d/override.conf
+++ b/files/common/lib/systemd/system/kdump-tools.service.d/override.conf
@@ -1,2 +1,0 @@
-[Unit]
-DefaultDependencies=yes


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

The kdump-tools service isn't starting properly, despite being enabled, due to a ordering issue; e.g.
```
Jul 08 21:27:04 ip-10-110-206-179 systemd[1]: basic.target: Found ordering cycle on kdump-tools.service/start
Jul 08 21:27:04 ip-10-110-206-179 systemd[1]: basic.target: Found dependency on basic.target/start
Jul 08 21:27:04 ip-10-110-206-179 systemd[1]: basic.target: Job kdump-tools.service/start deleted to break ordering cycle starting with basic.target/start
```

The problem is we added `DefaultDependencies=yes` via an override file in commit a6e89d76055ba78916af2d9b55683ff7357e81a6, and this is in conflict with the `Before=basic.target` directive in the "main" unit file.
</details>

<details open>
<summary><h2> Solution </h2></summary>
We need to keep `DefaultDependencies=yes` in order to ensure the service runs after local filesystems are mounted and ready, but we need to remove the `Before=basic.target` directive. In order to remove that directive, we have to completely override the main unit file in `/lib/systemd/system`, by creating a new one in `/etc/systemd/system`. Thus, that's what this change is doing; we're adding a new unit file in `/etc` that accomplishes our goals of using the default dependencies, and also removing the `Before=basic.target` directive.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11574/).
- I applied this change manually to a develop VM, rebooted the VM, and verified the `kdump-tools` service started correctly.
- I verified on the image generated by `git-ab-pre-push`, the `kdump-tools` service starts up on first boot:
```
$ systemctl status kdump-tools
● kdump-tools.service - Kernel crash dump capture service
     Loaded: loaded (/etc/systemd/system/kdump-tools.service; enabled; preset: enabled)
     Active: active (exited) since Wed 2025-07-09 15:37:58 UTC; 43s ago
   Main PID: 876 (code=exited, status=0/SUCCESS)
        CPU: 11.222s
```

</details>
