### PR TITLE
DLPX-94815 install zstd on the appliance

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -95,7 +95,8 @@ DEPENDS += ansible, \
 	   systemd-container, \
 	   systemd-resolved, \
 	   tzdata, \
-	   udev,
+	   udev, \
+	   zstd,
 
 #
 # The CRA PAM module provides an authentication method for the delphix user.


### PR DESCRIPTION
During an upgrade test, I noticed this in the output:

```
Jul 16 13:56:51 ip-10-110-236-229 upgrade-scripts:execute[1035]: + update-initramfs -u -t -k 5.15.0-1064-dx2024070515-22f636412-aws
Jul 16 13:56:51 ip-10-110-236-229 upgrade-scripts:execute[1035]: update-initramfs: Generating /boot/initrd.img-5.15.0-1064-dx2024070515-22f636412-aws
Jul 16 13:56:51 ip-10-110-236-229 upgrade-scripts:execute[1035]: W: No zstd in /usr/bin:/sbin:/bin, using gzip
```

It would be desirable to use zstd over gzip where possible, therefore we should have zstd installed.

Testing:

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11674/

On a VM cloned from the image generated by the above ab-pre-push run:
```
delphix@ip-10-110-230-231:~$ which zstd
/usr/bin/zstd
```