### PR TITLE
DLPX-95175 add bpfcc-tools to the base delphix image

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -127,6 +127,7 @@ DEPENDS += delphix-build-info,
 #
 DEPENDS += aptitude, \
 	   bcc, \
+	   bpfcc-tools, \
 	   bpftrace, \
 	   crash-python, \
 	   delphix-rust, \


### PR DESCRIPTION
Add bpfcc-tools to the base image, as it provides a collection of diagnostic tools that are generally useful.
