### PR TITLE
CP-12697 Enable SB for AWS on first boot (no shim)

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -69,6 +69,9 @@ configure)
 	systemctl enable delphix-rpool-upgrade.service
 	systemctl enable delphix.target
 
+	systemctl unmask delphix-sb-enroll.service
+	systemctl enable delphix-sb-enroll.service
+
 	if ! id -u postgres >/dev/null; then
 		# When installing postgres, a postgres user is created unless it
 		# already exists. To have a consistent UID accross installations

--- a/files/common/lib/systemd/system/delphix-sb-enroll.service
+++ b/files/common/lib/systemd/system/delphix-sb-enroll.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Enroll Secure Boot variables (PK/KEK/db) from .auth files
+Documentation=man:efi-updatevar(1)
+DefaultDependencies=no
+Before=delphix-platform.service
+After=var-delphix.mount local-fs.target
+ConditionPathExists=/var/delphix/server/sb_certs/
+
+[Service]
+Type=oneshot
+Environment=SB_AUTH_DIR=/var/delphix/server/sb_certs/
+ExecStart=/var/lib/delphix-sb-enroll/sb-enroll-efivars.sh
+# Prevent accidental re-runs the same boot unless you change the inputs
+RemainAfterExit=no
+
+[Install]
+WantedBy=delphix-platform.service
+

--- a/files/common/var/lib/delphix-sb-enroll/sb-enroll-efivars.sh
+++ b/files/common/var/lib/delphix-sb-enroll/sb-enroll-efivars.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+AUTH_DIR="${SB_AUTH_DIR:-/var/delphix/server/sb_certs/}"
+
+log() { printf '[sb-enroll] %s\n' "$*" >&2; }
+die() {
+	log "ERROR: $*"
+	exit 1
+}
+
+# Do nothing if Secure Boot is already enabled.
+sb=$(od -An -t u1 /sys/firmware/efi/efivars/SecureBoot-* | awk '{print $NF}')
+[[ $sb -eq 1 ]] && exit 0
+
+#
+# Run only on AWS.
+#
+# Expand this logic to support additional clouds.
+#
+if [[ $(get-appliance-platform) = "aws" ]]; then
+	log "AWS detected"
+else
+	log "Not AWS; skipping Secure Boot enrollment."
+	exit 0
+fi
+
+[[ -d /sys/firmware/efi/efivars ]] || die "Not booted in UEFI mode (/sys/firmware/efi/efivars missing)."
+
+# Ensure efivars is mounted (usually is on Ubuntu)
+if ! mountpoint -q /sys/firmware/efi/efivars; then
+	log "Mounting efivarfs..."
+	sudo mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+fi
+
+[[ -d "$AUTH_DIR" ]] || die "Auth directory not found: $AUTH_DIR"
+
+apply_auth() {
+	local var="$1" # db, KEK, PK
+	local file="$AUTH_DIR/${var}.auth"
+
+	sudo efi-updatevar -f "$file" "$var"
+	log "${var}: update submitted"
+}
+
+apply_auth db
+apply_auth KEK
+apply_auth PK
+
+log "Rebooting..."
+init 6


### PR DESCRIPTION

<details open>
<summary><h2> Background </h2></summary>
Secure boot have keys (auth files) enrolled in the instance's EFI firmware. Given we deliver an VM image, we want to enroll the keys on the instance's first boot.
</details>

<!--
<details open>
<summary><h2> Problem </h2></summary>

Provide a clear description of the high-level problem you are trying to
solve. The problem statement should be written in terms of a specific
symptom that affects users or the business. The problem statement should
not be written in terms of the solution. If possible, include a minimal
reproducible example (MRE) with steps to reproduce, expected results,
and actual results.
</details>
-->

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
A new delphix-sb-enroll.service that enrolls the keys and immediately reboots the system. This way our appliance will boot with secure boot as early as possible, before delphix-platform.service runs for the first time.

The delphix-sb-enroll service will activate secure-boot only for VMs running on AWS, i.e. does nothing for VMs on other cloud platforms. And enrollment is done only once, subsequent reboots have no effect. 
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- AWS installation
```
delphix@ip-10-110-210-77:~$ sudo dpkg -i delphix-platform-aws_2025.08.22.17_amd64.deb
(Reading database ... 180788 files and directories currently installed.)
Preparing to unpack delphix-platform-aws_2025.08.22.17_amd64.deb ...
+ case $1 in
+ systemctl disable delphix.target
Removed "/etc/systemd/system/default.target.wants/delphix.target".
+ systemctl disable delphix-platform.service
Removed "/etc/systemd/system/delphix.target.wants/delphix-platform.service".
....
+ systemctl enable delphix.target
Created symlink /etc/systemd/system/default.target.wants/delphix.target → /usr/lib/systemd/system/delphix.target.
+ systemctl unmask delphix-sb-enroll.service
+ systemctl enable delphix-sb-enroll.service
Created symlink /etc/systemd/system/multi-user.target.wants/delphix-sb-enroll.service → /usr/lib/systemd/system/delphix-sb-enroll.service.
+ id -u postgres
++ id -u postgres
+ [[ 65437 -ne 65437 ]]
+ DEFAULT_UDEV_NET_SETUP_LINK_DIR=/usr/lib/udev/rules.d
+ MODIFIED_UDEV_NET_SETUP_LINK_DIR=/etc/udev/rules.d
+ [[ ! -e /usr/lib/udev/rules.d/80-net-setup-link.rules ]]
++ get-appliance-platform
+ [[ aws == \a\w\s ]]
+ mkdir -p /etc/udev/rules.d
+ cp /usr/lib/udev/rules.d/80-net-setup-link.rules /etc/udev/rules.d
+ sed -i 's/NAME=="", ENV{ID_NET_NAME}!="", NAME="$env{ID_NET_NAME}"/NAME=="", ENV{ID_NET_NAME_MAC}!="", NAME="$env{ID_NET_NAME_MAC}"/' /etc/udev/rules.d/80-net-setup-link.rules
++ uname -r
+ update-initramfs -u -t -k 6.14.0-1010-dx2025082120-f9bbb315e-aws
update-initramfs: Generating /boot/initrd.img-6.14.0-1010-dx2025082120-f9bbb315e-aws
Couldn't find EFI system partition. It is recommended to mount it to /boot or /efi.
Alternatively, use --esp-path= to specify path to mount point.
+ exit 0
delphix@ip-10-110-210-77:~$ sudo init 6

```
Secure boot is enabled after reboot
```
delphix@ip-10-110-210-77:~$ bootctl status | grep -i "secure boot"
Couldn't find EFI system partition. It is recommended to mount it to /boot or /efi.
Alternatively, use --esp-path= to specify path to mount point.
   Secure Boot: enabled (user)
   ```
 Verified service ran and rebooted
 ```
delphix@ip-10-110-210-77:~$ sudo journalctl -xu delphix-sb-enroll
Aug 22 18:43:57 ip-10-110-210-77 systemd[1]: Starting delphix-sb-enroll.service - Enroll Secure Boot variables (PK/KEK/db) from .auth files...
░░ Subject: A start job for unit delphix-sb-enroll.service has begun execution
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
░░
░░ A start job for unit delphix-sb-enroll.service has begun execution.
░░
░░ The job identifier is 114.
Aug 22 18:43:58 ip-10-110-210-77 sb_enroll_efivars.sh[4516]: [sb-enroll] AWS detected (via DMI)
Aug 22 18:43:58 ip-10-110-210-77 sudo[4560]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/efi-updatevar -f /var/delphix/server/sb_keys//db.auth db
Aug 22 18:43:58 ip-10-110-210-77 sudo[4560]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Aug 22 18:43:58 ip-10-110-210-77 sudo[4560]: pam_unix(sudo:session): session closed for user root
Aug 22 18:43:58 ip-10-110-210-77 sb_enroll_efivars.sh[4516]: [sb-enroll] db: update submitted
Aug 22 18:43:58 ip-10-110-210-77 sudo[4865]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/efi-updatevar -f /var/delphix/server/sb_keys//KEK.auth KEK
Aug 22 18:43:58 ip-10-110-210-77 sudo[4865]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Aug 22 18:43:58 ip-10-110-210-77 sudo[4865]: pam_unix(sudo:session): session closed for user root
Aug 22 18:43:58 ip-10-110-210-77 sb_enroll_efivars.sh[4516]: [sb-enroll] KEK: update submitted
Aug 22 18:43:58 ip-10-110-210-77 sudo[4891]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/efi-updatevar -f /var/delphix/server/sb_keys//PK.auth PK
Aug 22 18:43:58 ip-10-110-210-77 sudo[4891]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Aug 22 18:43:58 ip-10-110-210-77 sudo[4891]: pam_unix(sudo:session): session closed for user root
Aug 22 18:43:58 ip-10-110-210-77 sb_enroll_efivars.sh[4516]: [sb-enroll] PK: update submitted
Aug 22 18:43:58 ip-10-110-210-77 sb_enroll_efivars.sh[4516]: [sb-enroll] Rebooting...
Aug 22 18:43:59 ip-10-110-210-77 systemd[1]: delphix-sb-enroll.service: Deactivated successfully.
░░ Subject: Unit succeeded
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
```

- Azure installation
```
delphix@tonyn-azure-sb1:~$ sudo dpkg -i delphix-platform-azure_2025.08.22.17_amd64.deb
(Reading database ... 208638 files and directories currently installed.)
Preparing to unpack delphix-platform-azure_2025.08.22.17_amd64.deb ...
+ case $1 in
+ systemctl disable delphix.target
Removed "/etc/systemd/system/default.target.wants/delphix.target".
+ systemctl disable delphix-platform.service
Removed "/etc/systemd/system/delphix.target.wants/delphix-platform.service".
+ systemctl disable delphix-rpool-upgrade.service
Removed "/etc/systemd/system/delphix.target.wants/delphix-rpool-upgrade.service".
....
+ systemctl enable delphix-rpool-upgrade.service
Created symlink /etc/systemd/system/delphix.target.wants/delphix-rpool-upgrade.service → /usr/lib/systemd/system/delphix-rpool-upgrade.service.
+ systemctl enable delphix.target
Created symlink /etc/systemd/system/default.target.wants/delphix.target → /usr/lib/systemd/system/delphix.target.
+ systemctl unmask delphix-sb-enroll.service
+ systemctl enable delphix-sb-enroll.service
Created symlink /etc/systemd/system/multi-user.target.wants/delphix-sb-enroll.service → /usr/lib/systemd/system/delphix-sb-enroll.service.
+ id -u postgres
++ id -u postgres
+ [[ 65437 -ne 65437 ]]
+ DEFAULT_UDEV_NET_SETUP_LINK_DIR=/usr/lib/udev/rules.d
+ MODIFIED_UDEV_NET_SETUP_LINK_DIR=/etc/udev/rules.d
+ [[ ! -e /usr/lib/udev/rules.d/80-net-setup-link.rules ]]
++ get-appliance-platform
+ [[ azure == \a\w\s ]]
+ exit 0
```
Verify service does nothing on start (not AWS)
```
delphix@tonyn-azure-sb1:~$ systemctl status delphix-sb-enroll
○ delphix-sb-enroll.service - Enroll Secure Boot variables (PK/KEK/db) from .auth files
     Loaded: loaded (/usr/lib/systemd/system/delphix-sb-enroll.service; enabled; preset: enabled)
     Active: inactive (dead)
       Docs: man:efi-updatevar(1)
delphix@tonyn-azure-sb1:~$ sudo systemctl start delphix-sb-enroll
delphix@tonyn-azure-sb1:~$
delphix@tonyn-azure-sb1:~$
delphix@tonyn-azure-sb1:~$
delphix@tonyn-azure-sb1:~$ systemctl status delphix-sb-enroll
○ delphix-sb-enroll.service - Enroll Secure Boot variables (PK/KEK/db) from .auth files
     Loaded: loaded (/usr/lib/systemd/system/delphix-sb-enroll.service; enabled; preset: enabled)
     Active: inactive (dead) since Fri 2025-08-22 18:55:46 UTC; 4s ago
       Docs: man:efi-updatevar(1)
    Process: 15674 ExecStart=/var/lib/delphix-sb-enroll/sb_enroll_efivars.sh (code=exited, status=0/SUCCESS)
   Main PID: 15674 (code=exited, status=0/SUCCESS)
        CPU: 8ms
        
delphix@tonyn-azure-sb1:~$ sudo journalctl -xu delphix-sb-enroll
Aug 22 18:55:46 tonyn-azure-sb1 systemd[1]: Starting delphix-sb-enroll.service - Enroll Secure Boot variables (PK/KEK/db) from .auth files...
░░ Subject: A start job for unit delphix-sb-enroll.service has begun execution
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
░░
░░ A start job for unit delphix-sb-enroll.service has begun execution.
░░
░░ The job identifier is 1633.
Aug 22 18:55:46 tonyn-azure-sb1 sb_enroll_efivars.sh[15674]: [sb-enroll] Not AWS; skipping Secure Boot enrollment.
Aug 22 18:55:46 tonyn-azure-sb1 systemd[1]: delphix-sb-enroll.service: Deactivated successfully.
░░ Subject: Unit succeeded
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
░░
░░ The unit delphix-sb-enroll.service has successfully entered the 'dead' state.
```

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
