### PR TITLE
DLPX-95109 could not find 'spa_t *' when running sdb -e 'spa' on dump

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -515,7 +515,9 @@
 # MAKEDUMP_ARGS - Configure makedumpfile to:
 #       [1] Compress the dump (-c)
 #       [2] Filter out pages that are zero, in the page or private cache,
-#           part of user data, or marked as freed (-d 31)
+#           or marked as freed (-d 23)
+#           Note that we do not exclude the "user data" pages, as these
+#           are needed for drgn to be able to load zfs module symbols
 #       [3] Output a progress indicator, common and error messages, and
 #           a report summary message (--message-level 23)
 #       [4] Exclude ZFS ARC file data pages
@@ -558,7 +560,7 @@
     line: "{{ item.line }}"
   with_items:
     - regex: '^#?MAKEDUMP_ARGS='
-      line: 'MAKEDUMP_ARGS="-c -d 31 --message-level 23 --private-page-filter 0x2F5ABDF11ECAC4E"'
+      line: 'MAKEDUMP_ARGS="-c -d 23 --message-level 23 --private-page-filter 0x2F5ABDF11ECAC4E"'
     - regex: '^#?KDUMP_CMDLINE_APPEND='
       line: 'KDUMP_CMDLINE_APPEND="reset_devices systemd.unit=kdump-tools-dump.service nr_cpus=1 irqpoll nousb ata_piix.prefer_ms_hyperv=0 panic=10"'
 


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

We sometimes see that the the `spa` command works, but often not. After
some investigation it became clear that the issue here is that required
pages were being excluded from the generated dump file (as a result of
the `makedumpfile` `-d` flag) that result in `drgn` ignoring multiple kernel
modules (including the zfs module).
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Trial and error testing revealed that switching from `-d 31` (default
setting for makedumpfile that excludes all pages it deems unnecessary
for debugging) to `-d 23` (excluding all those pages except the
“user data” pages) results in a dump file that is larger, but also
does not cause `drgn` to report “Excluded page” errors at startup.
This version of the dump file appears to allow full `sdb` debugging.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/12045/
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
