### PR TITLE
DLPX-95335 delphix-sb-enroll.service fails on OCI VMs

### DIFF
--- a/files/common/var/lib/delphix-sb-enroll/sb-enroll-efivars.sh
+++ b/files/common/var/lib/delphix-sb-enroll/sb-enroll-efivars.sh
@@ -9,10 +9,6 @@ die() {
 	exit 1
 }
 
-# Do nothing if Secure Boot is already enabled.
-sb=$(od -An -t u1 /sys/firmware/efi/efivars/SecureBoot-* | awk '{print $NF}')
-[[ $sb -eq 1 ]] && exit 0
-
 #
 # Run only on AWS.
 #
@@ -26,6 +22,10 @@ else
 fi
 
 [[ -d /sys/firmware/efi/efivars ]] || die "Not booted in UEFI mode (/sys/firmware/efi/efivars missing)."
+
+# Do nothing if Secure Boot is already enabled.
+sb=$(od -An -t u1 /sys/firmware/efi/efivars/SecureBoot-* | awk '{print $NF}')
+[[ $sb -eq 1 ]] && exit 0
 
 # Ensure efivars is mounted (usually is on Ubuntu)
 if ! mountpoint -q /sys/firmware/efi/efivars; then


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

On OCI VMs, the service fails to start
```
delphix@tonyn-oci-1-nic-1:~$ systemctl status delphix-sb-enroll
× delphix-sb-enroll.service - Enroll Secure Boot variables (PK/KEK/db) from .auth files
     Loaded: loaded (/usr/lib/systemd/system/delphix-sb-enroll.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Thu 2025-09-04 15:11:07 UTC; 1min 47s ago
       Docs: man:efi-updatevar(1)
   Main PID: 527 (code=exited, status=1/FAILURE)
        CPU: 16ms
```

It turned out the OCI VMs don’t have the SecureBoot efivar, likely because secure boot is explicitly disabled.
```
delphix@tonyn-oci-1-nic-1:~$ sudo journalctl -u delphix-sb-enroll.service
Sep 04 15:11:07 tonyn-oci-1-nic-1 sb-enroll-efivars.sh[533]: od: '/sys/firmware/efi/efivars/SecureBoot-*': No such file or directory
Sep 04 15:11:07 tonyn-oci-1-nic-1 systemd[1]: Starting delphix-sb-enroll.service - Enroll Secure Boot variables (PK/KEK/db) from .auth files...
Sep 04 15:11:07 tonyn-oci-1-nic-1 systemd[1]: delphix-sb-enroll.service: Main process exited, code=exited, status=1/FAILURE
Sep 04 15:11:07 tonyn-oci-1-nic-1 systemd[1]: delphix-sb-enroll.service: Failed with result 'exit-code'.
Sep 04 15:11:07 tonyn-oci-1-nic-1 systemd[1]: Failed to start delphix-sb-enroll.service - Enroll Secure Boot variables (PK/KEK/db) from .auth files.

delphix@tonyn-oci-1-nic-1:~$ ls /sys/firmware/efi/efivars/SecureBoot-*
ls: cannot access '/sys/firmware/efi/efivars/SecureBoot-*': No such file or directory
```
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
A simple fix would be to move the check for AWS platform to earlier since secure boot is only supported on AWS at the moment. This way we wouldn’t even look for SecureBoot efivar for non-AWS systems.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>
Confirmed delphix-sb-enroll.service no longer fails on all platforms.

Successful appliance builds:
OCI - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/12072/console
ESX, AWS, Azure, GCP - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/12080/console
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
