### PR TITLE
DLPX-95481 Add multipath-tools pkg to Delphix appliance

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -45,6 +45,9 @@ configure)
 	systemctl disable motd-news.service
 	systemctl disable motd-news.timer
 
+	# Disable multipathd service by default. It will be enabled if the iSCSI initiator feature is used
+  systemctl disable multipathd.service
+
 	#
 	# Various tools generate mail on the system, e.g. cron, and we don't
 	# want those to be sent externally via SMTP (or equivalent). Thus,

--- a/debian/rules
+++ b/debian/rules
@@ -75,6 +75,7 @@ DEPENDS += ansible, \
 	   lsb-release, \
 	   makedumpfile, \
 	   mount, \
+	   multipath-tools, \
 	   net-tools, \
 	   netbase, \
 	   netplan.io, \


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

Support AWS FSx with NetApp ONTAP using their iSCSI volumes as block devices for Delphix database storage (domain0).  The initial phase of support will be a POV targeted for the Nov 2025 release.

</details>


<details open>
<summary><h2> Problem </h2></summary>

AWS FSx with NetApp ONTAP support requires the Delphix iSCSI Initiator feature to be enabled in order to consume the NetApp iSCSI volumes.  These iSCSI volumes have multiple paths which is a requirement to support AWS FSx.  The first step in supporting this is to include the multipath-tools pkg which contains the multipathd service.
  
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add `multipath-tools` to the debian rules.
We don't want the `multipathd` service automatically running since it's only needed when the iSCSI initiator feature is enabled (currently behind a feature flag).

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/12196/ 

Upgrade test is failing probably due to https://perforce.atlassian.net/browse/TOOL-28580 

Verify engine has the pkg installed and not running.
```
root@ip-10-110-202-19:/export/home/delphix# dpkg --list |grep multipath-tool
ii  multipath-tools                                            0.9.4-5ubuntu8                                                                                  amd64        maintain multipath block device access
root@ip-10-110-202-19:/export/home/delphix# systemctl status multipathd
○ multipathd.service - Device-Mapper Multipath Device Controller
     Loaded: loaded (/usr/lib/systemd/system/multipathd.service; disabled; preset: enabled)
     Active: inactive (dead)
TriggeredBy: ○ multipathd.socket
root@ip-10-110-202-19:/export/home/delphix#
```

Verified service can be started and the conf file exists:
```
root@ip-10-110-202-19:/export/home/delphix# systemctl status multipathd
● multipathd.service - Device-Mapper Multipath Device Controller
     Loaded: loaded (/usr/lib/systemd/system/multipathd.service; disabled; preset: enabled)
     Active: active (running) since Fri 2025-09-19 20:49:44 UTC; 1s ago
TriggeredBy: ○ multipathd.socket
    Process: 20680 ExecStartPre=/sbin/modprobe dm-multipath (code=exited, status=0/SUCCESS)
   Main PID: 20682 (multipathd)
     Status: "up"
      Tasks: 7
     Memory: 23.7M (peak: 23.9M)
        CPU: 92ms
     CGroup: /system.slice/multipathd.service
             └─20682 /sbin/multipathd -d -s

Sep 19 20:49:44 ip-10-110-202-19 systemd[1]: Starting multipathd.service - Device-Mapper Multipath Device Controller...
Sep 19 20:49:44 ip-10-110-202-19 multipathd[20682]: multipathd v0.9.4: start up
Sep 19 20:49:44 ip-10-110-202-19 multipathd[20682]: reconfigure: setting up paths and maps
Sep 19 20:49:44 ip-10-110-202-19 systemd[1]: Started multipathd.service - Device-Mapper Multipath Device Controller.
root@ip-10-110-202-19:/export/home/delphix# cat /etc/multipath.conf
defaults {
    user_friendly_names yes
}
root@ip-10-110-202-19:/export/home/delphix#
```

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
