### PR TITLE
DLPX-95602 X11 console Keymaps broken

### DIFF
--- a/files/common/usr/bin/delphix-startup-screen
+++ b/files/common/usr/bin/delphix-startup-screen
@@ -22,9 +22,12 @@ the IP address, hostname, and services (description and status).
 import curses
 import curses.ascii
 import curses.textpad
+import re
 import sys
 import signal
 import os
+import shutil
+import tempfile
 import logging
 import subprocess
 from typing import List, Any, Tuple, Generator
@@ -102,11 +105,66 @@ def get_keyboard_layout() -> str:
 
 def set_keyboard_layout(layout: str) -> subprocess.CompletedProcess:
     """
-    Set the keyboard layout based on the user selection.
+    Set the keyboard layout by editing /etc/default/keyboard and applying it with setupcon.
+    This avoids localectl (which is disabled on Debian/Ubuntu builds).
+
+    Notes:
+      - Does NOT trigger update-initramfs; only applies to the running system's console. Delphix
+        doesn't have TTY interactions before pivot-root, e.g. encrypted root passphrase, and
+        rescue shell can be done with the default "us" layout.
     """
-    cmd: List[str] = ['localectl', 'set-x11-keymap', layout, 'pc105']
-    subprocess.run(cmd, shell=False, check=True)
-    return subprocess.run('setupcon', shell=False, check=True)
+    kb_path = "/etc/default/keyboard"
+    kb_backup = kb_path + ".bak"
+
+    # Read current content (if file doesn't exist, start with a minimal stub)
+    try:
+        with open(kb_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        lines = [
+            'XKBMODEL="pc105"\n',
+            f'XKBLAYOUT="{layout}"\n',
+            'XKBVARIANT=""\n',
+            'XKBOPTIONS=""\n',
+            'BACKSPACE="guess"\n',
+        ]
+    else:
+        # Update or append XKBLAYOUT line
+        updated = False
+        pattern = re.compile(r'^\s*XKBLAYOUT\s*=')
+        for i, line in enumerate(lines):
+            if pattern.match(line):
+                lines[i] = f'XKBLAYOUT="{layout}"\n'
+                updated = True
+                break
+        if not updated:
+            # Append if not present
+            lines.append(f'XKBLAYOUT="{layout}"\n')
+
+    # Atomic write with backup
+    os.makedirs(os.path.dirname(kb_path), exist_ok=True)
+    if os.path.exists(kb_path):
+        shutil.copy2(kb_path, kb_backup)
+
+    fd, tmp = tempfile.mkstemp(prefix=".keyboard.",
+                               dir=os.path.dirname(kb_path))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+        os.replace(tmp, kb_path)
+    except Exception:
+        # Clean temp file and restore from backup if we wrote a partial file
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        if os.path.exists(kb_backup):
+            shutil.copy2(kb_backup, kb_path)
+        raise
+
+    # Apply to current console immediately (does not affect serial consoles)
+    # Use --force so it rebuilds/loads even if it thinks nothing changed.
+    return subprocess.run(["setupcon", "--force"], shell=False, check=True)
 
 
 def get_valid_keyboard_layouts() -> List[str]:


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

To update keymapping, `/usr/bin/delphix-startup-screen` uses `sudo localectl set-x11-keymap` which is no longer the supported mechanism in Ubuntu 24.04 release. Below shows the error when running the command
```
delphix@localhost:~$ sudo localectl set-x11-keymap us
Setting X11 and console keymaps is not supported in Debian.
``` 

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Set the keyboard layout by editing /etc/default/keyboard and applying it with `setupcon`. This mechanism avoids `localectl set-x11-keymap` (which is disabled on Debian/Ubuntu builds).

Notes:
      - This change does NOT trigger update-initramfs; only applies to the running system's console. Delphix
        doesn't have TTY interactions before pivot-root, e.g. encrypted root passphrase, and
        rescue shell can be done with the default "us" layout.
       - `dpkg-reconfigure keyboard-configuration` is another way to update keymap which would also do `update-initramfs` which is unnecessary and more involved, mounting and unmounting EFI partition.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Updating to different keyboard layouts and verified `dumpkeys(1)` produced different key mappings.
```
-rw-r-----  1 delphix staff 470395 Oct 24 19:19 dumpkeys.gb
-rw-r-----  1 delphix staff 446504 Oct 24 19:21 dumpkeys.jp
-rw-r-----  1 delphix staff 453750 Oct 24 19:21 dumpkeys.us.1
-rw-r-----  1 delphix staff 477181 Oct 24 19:23 dumpkeys.de
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
