### PR TITLE
DLPX-96025 zfs_arc_meta_strategy no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,38 @@
 
 ### Building
 
+#### Prerequisites: SSH Key Setup
+
+Before cloning a build VM, ensure your SSH keys are loaded in ssh-agent so they
+are automatically installed on the VM for passwordless access:
+
+    $ ssh-add -l                    # Check if keys are loaded
+    $ ssh-add ~/.ssh/id_ed25519     # Load your key if not already loaded
+
+The `dc clone-latest` command will automatically install your public key from
+ssh-agent onto the VM. If no key is available, you'll see a warning and the
+VM won't be accessible via SSH key authentication.
+
+**Manual SSH Key Setup (if automatic setup fails):**
+
+If you cloned the VM before loading your keys, or the automatic setup didn't
+work, you can manually configure passwordless SSH. First, log in with standard
+password:
+
+    $ ssh delphix@$USER-bootstrap.dlpxdc.co
+
+Then add your public key to authorized_keys:
+
+    $ mkdir -p ~/.ssh && chmod 700 ~/.ssh
+    $ echo "YOUR_PUBLIC_KEY_HERE" >> ~/.ssh/authorized_keys
+    $ chmod 600 ~/.ssh/authorized_keys
+
+To get your public key, run this on your local machine:
+
+    $ cat ~/.ssh/id_ed25519.pub     # or id_rsa.pub
+
+#### Create Build VM
+
 Run this command on "dlpxdc.co" to create the VM used to do the build:
 
     $ dc clone-latest --size COMPUTE_LARGE dlpx-internal-buildserver-develop $USER-bootstrap
@@ -12,9 +44,26 @@ Log into that VM using the "delphix" user, and run these commands:
 
     $ git clone https://github.com/delphix/delphix-platform.git
     $ cd delphix-platform
-    $ sudo apt-get update && sudo apt-get install python3-docker
-    $ ansible-playbook bootstrap/playbook.yml
-    $ ./scripts/docker-run.sh make packages
+
+#### Bootstrap and Build
+
+    $ sudo apt-get update && sudo apt-get install -y docker.io python3-pip
+    $ sudo pip3 install docker --break-system-packages
+    $ sudo usermod -aG docker $USER
+    $ sudo docker build -t delphix-platform docker/
+    $ sg docker -c './scripts/docker-run.sh make packages'
+
+#### Build Specific Platforms
+
+To build for a specific platform instead of all platforms:
+
+    $ ./scripts/docker-run.sh make package-aws      # AWS only
+    $ ./scripts/docker-run.sh make package-azure    # Azure only
+    $ ./scripts/docker-run.sh make package-esx      # ESX only
+
+Available platforms: aws, azure, esx, gcp, hyperv, kvm, oci
+
+Build artifacts are placed in the `artifacts/` directory.
 
 ## Contributing
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -46,7 +46,7 @@ configure)
 	systemctl disable motd-news.timer
 
 	# Disable multipathd service by default. It will be enabled if the iSCSI initiator feature is used
-  systemctl disable multipathd.service
+	systemctl disable multipathd.service
 
 	#
 	# Various tools generate mail on the system, e.g. cron, and we don't

--- a/files/common/lib/modprobe.d/10-zfs.conf
+++ b/files/common/lib/modprobe.d/10-zfs.conf
@@ -84,21 +84,6 @@ options zfs zfs_mg_noalloc_threshold=5
 options zfs zfs_override_estimate_recordsize=8192
 
 #
-# The default arc metadata eviction policy is a balanced policy. This policy
-# evicts both data and metadata and provides a callback to the ZPL layer
-# to evict blocks from the inode and dentry caches. This policy has serious
-# implications because it tries too hard to reduce metadata so that it's
-# below the arc_meta_limit. As a result this can end up consuming all of
-# the cpus and causing the system to run out of memory. Since the arc
-# metadata eviction is called in the critical path, we want a lightweight
-# policy to be used to ensure that eviction happens quickly and new additions
-# to the arc are not blocked for a significant amount of time. To do this,
-# we changes the metadata eviction policy to ARC_STRATEGY_META_ONLY,
-# which is what we used in illumos.
-#
-options zfs zfs_arc_meta_strategy=0
-
-#
 # Increasing zvol taskq threads to 256 to improve performance for some
 # workloads. Taskq threads are created and destroyed dynamically so there
 # should be minimal to no impact on small systems.


### PR DESCRIPTION
## Summary
- Remove obsolete `zfs_arc_meta_strategy` ZFS parameter from modprobe configuration

The upstream ZFS [commit 3c639bf4f16952](https://github.com/openzfs/zfs/commit/3c639bf4f16952abde91450e972da7942266e5e9) rewrote the ARC eviction logic to be more adaptive, removing the `zfs_arc_meta_strategy` parameter entirely. This change removes the now-invalid setting from `files/common/lib/modprobe.d/10-zfs.conf`.

Created [DLPX-96054](https://perforce.atlassian.net/browse/DLPX-96054) to track the follow-up investigation of `zfs_arc_meta_balance` tuning as called out by Mark in the ticket.

## Test plan
- [x] Verify package builds successfully
- [ ] Confirm ZFS module loads without errors on upgraded appliance (reviewers, is this needed?)

### Test build results

| Test Plan Item                  | Status                               |
|---------------------------------|--------------------------------------|
| Package builds successfully     | Passed - all 7 platforms built       |
| ZFS module loads without errors | Requires testing on actual appliance |

### Built Packages

Built on `dbj-test-bootstrap.dlpxdc.co:~/delphix-platform/artifacts/`:
- delphix-platform-aws_2025.12.01.19_amd64.deb
- delphix-platform-azure_2025.12.01.19_amd64.deb
- delphix-platform-esx_2025.12.01.19_amd64.deb
- delphix-platform-gcp_2025.12.01.19_amd64.deb
- delphix-platform-hyperv_2025.12.01.19_amd64.deb
- delphix-platform-kvm_2025.12.01.19_amd64.deb
- delphix-platform-oci_2025.12.01.19_amd64.deb

#### Bonus: README.md Updated

_fixed as I worked through build setup, see `dbj-test-bootstrap.dlpxdc.co`_

1. SSH key setup instructions for `dc clone-latest`
2. Ubuntu 24.04+ workaround (python3-docker unavailable)
3. Build specific platform instructions
4. Artifact location info

