### PR TITLE
CP-13126 Update delphix-platform to install docker from official docker repo instead of docker.io

### DIFF
--- a/bootstrap/roles/delphix-platform.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/delphix-platform.bootstrap/tasks/main.yml
@@ -21,9 +21,19 @@
 - apt:
     name: "{{ item }}"
     state: present
-  with_items:
-    - docker.io
+  loop:
+    - nftables
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
     - python3-docker
+
+- name: Execute 'systemctl start docker' command
+  ansible.builtin.command: systemctl start docker
+  register: docker_start_result
+  retries: 10
+  delay: 30
+  until: docker_start_result.rc == 0
 
 - docker_image:
     build:


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

We are using docker.io which is the default ubuntu package for installing docker, but the version is not in sync with the actual docker-ce version.

To be in sync with the docker-ce version we need to install the docker from official docker repositories. The docker repositories are already downloaded to ubuntu mirror and are being pulled during sudo apt-get update using https://github.com/delphix/linux-pkg/pull/381

</details>

<details open>
<summary><h2> Solution </h2></summary>

Updated the docker installation with docker-ce. Details about each package

- docker-ce -> Needed for the installation of docker community addition.
- docker-ce-cli -> Needed for running commands via CLI
- containerd.io -> docker-ce and docker-ce-cli are dependent on the components for containerd.io
- nftables -> With the release of docker version 29.x.x, it is necessary requirement as docker had started supporting iptables rules via nftables also.

Also, once all the components are installed, we have to start the service via systemctl command. What I found out is that first time installation on a machine with docker.io installed, the service needed to be started multiple times. So, I have to add retry mechanism
  - Also, running the ansible file again does not have the same issue as the docker is started without issues.
  - So, we should not face the same issue once the machine has docker-ce installed.

I tried multiple approaches like stopping the docker service, uninstalling all docker components and then starting the service and waiting for it to come online. But faced the same issue again and again.

</details>

<details open>
<summary><h2> Merging Details </h2></summary>
Still checking if it can be merged alone..
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

- Tried on a server by cloning dlpx-internal-buildserver-develop.
- As per screenshot, running it first time has retries.
- Running it again does not have retries.
<img width="1212" height="832" alt="Screenshot 2026-02-09 at 7 49 52 PM" src="https://github.com/user-attachments/assets/6750851b-77c5-44e3-96f0-2b0d832468ab" />

</details>
