### PR TITLE
DLPX-96941 Replace ntpsec with chrony (delphix-platform changes)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -79,7 +79,7 @@ DEPENDS += ansible, \
 	   net-tools, \
 	   netbase, \
 	   netplan.io, \
-	   ntpsec, \
+	   chrony, \
 	   nullmailer, \
 	   open-iscsi, \
 	   openssh-server, \


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

The Delphix appliance previously used `ntpsec` as its NTP daemon (and before that, the legacy `ntp` package). Both packages are being replaced with `chrony` ([DLPX-96940](https://perforce.atlassian.net/browse/DLPX-96940)/[96941](https://perforce.atlassian.net/browse/DLPX-96941)/[96942](https://perforce.atlassian.net/browse/DLPX-96942)), motivated by two factors:

1. **Security ([DLPX-86999](https://perforce.atlassian.net/browse/DLPX-86999), Qualys QID 38293):** `ntpsec` and `ntp` respond to NTP mode 6/7 queries, exposing sensitive system information (OS version, kernel, stratum, etc.) that can aid further attacks against the system. `chrony` does not support these query modes by default, eliminating the disclosure.
2. **Ubuntu 25.04 compatibility:** The Delphix Engine is planned to move to Ubuntu 25.04 later this year, where `chrony` is the default NTP daemon. Making this switch now avoids duplicating the migration effort at that time.
</details>

<details open>
<summary><h2> Companion PRs </h2></summary>

This PR is part of a set of four that must merge together:

- [dlpx-app-gate#4244](https://github.com/delphix/dlpx-app-gate/pull/4244) — app-stack changes
- This PR — platform changes
- [appliance-build#857](https://github.com/delphix/appliance-build/pull/857) — upgrade/migration scripts
- [dlpx-qa-gate#8297](https://github.com/delphix/dlpx-qa-gate/pull/8297) — QA gate test updates
</details>

<details open>
<summary><h2> Problem </h2></summary>

The Delphix Engine's Debian package declared `ntpsec` as a dependency in `debian/rules`. This needs to be replaced with `chrony`.
</details>

<details open>
<summary><h2> Solution </h2></summary>

One-line change in `debian/rules`: `ntpsec` replaced with `chrony` in the `DEPENDS` list.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

Full appliance build including all three companion PRs verified on Jenkins:

| Build | Description | Status |
|---|---|---|
| [#13927](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13927/) | Full build + upgrade from 2025.3.0.1 | UNSTABLE — dx-integration-tests: `NtpServerMonitoringTest` flakiness (fixed; see second set of runs below) |
| [#13928](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13928/) | Full build + upgrade from 2025.6.0.0 | SUCCESS |
| [#13929](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13929/) | Full build + upgrade from 2026.2.0.0 | UNSTABLE — upgrade-testing: pre-existing failure unrelated to this change |
| [#13930](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13930/) | Full build | UNSTABLE — upgrade-testing: pre-existing failure unrelated to this change |
| [#13941](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13941/) | Full build + upgrade from 2025.3.0.1 | RUNNING |
| [#13938](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13938/) | Full build + upgrade from 2025.6.0.0 | RUNNING |
| [#13940](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13940/) | Full build + upgrade from 2026.2.0.0 | RUNNING |
| [#13939](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13939/) | Full build | RUNNING |

> **Note:** The git workflow runs with only this repo's changes, without the companion changes in [dlpx-app-gate#4244](https://github.com/delphix/dlpx-app-gate/pull/4244) and [appliance-build#857](https://github.com/delphix/appliance-build/pull/857). The `appliance-build-orchestrator-pre-push` runs pull in all three companion PRs together, so their results reflect the full end-to-end change.
</details>

