### PR TITLE
DLPX-96697 enable post-quantum key exchange algorithms for the SSH server

### DIFF
--- a/files/common/etc/ssh/sshd_config.d/9-delphix.conf
+++ b/files/common/etc/ssh/sshd_config.d/9-delphix.conf
@@ -16,7 +16,7 @@ AllowTcpForwarding no
 X11Forwarding no
 
 Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
-KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
 MACs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512
 HostKeyAlgorithms -ssh-rsa*
 


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

SSH client version 10.1 emits below warning if a non post-quantum key exchange is used for the connection  
```
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
```

See more context at https://www.openssh.org/pq.html

Delphix appliance has OpenSSH version 9.6 which supports **sntrup761x25519-sha512@openssh.com** post-quantum algorithm so we should enable that.
```
delphix@ip-10-110-201-107:~$ ssh -V
OpenSSH_9.6p1 Ubuntu-3ubuntu13.14, OpenSSL 3.0.13 30 Jan 2024

delphix@ip-10-110-201-107:~$ ssh -Q kex
diffie-hellman-group1-sha1
diffie-hellman-group14-sha1
diffie-hellman-group14-sha256
diffie-hellman-group16-sha512
diffie-hellman-group18-sha512
diffie-hellman-group-exchange-sha1
diffie-hellman-group-exchange-sha256
ecdh-sha2-nistp256
ecdh-sha2-nistp384
ecdh-sha2-nistp521
curve25519-sha256
curve25519-sha256@libssh.org
sntrup761x25519-sha512@openssh.com
```
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Enable the supported post-quantum algorithm in OpenSSH 9.6.

Also, the Delphix supported MACs and Ciphers are up-to-date

**MACs**
```
delphix@ip-10-110-201-107:~$ ssh -V
OpenSSH_9.6p1 Ubuntu-3ubuntu13.14, OpenSSL 3.0.13 30 Jan 2024

delphix@ip-10-110-201-107:~$ grep ^MACs /etc/ssh/sshd_config.d/9-delphix.conf
MACs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512

delphix@ip-10-110-201-107:~$ ssh -Q mac
hmac-sha1
hmac-sha1-96
hmac-sha2-256
hmac-sha2-512
hmac-md5
hmac-md5-96
umac-64@openssh.com
umac-128@openssh.com
hmac-sha1-etm@openssh.com
hmac-sha1-96-etm@openssh.com
hmac-sha2-256-etm@openssh.com
hmac-sha2-512-etm@openssh.com
hmac-md5-etm@openssh.com
hmac-md5-96-etm@openssh.com
umac-64-etm@openssh.com
umac-128-etm@openssh.com
```

**Ciphers**
```
delphix@ip-10-110-201-107:~$ grep ^Ciphers /etc/ssh/sshd_config.d/9-delphix.conf
Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com

delphix@ip-10-110-201-107:~$ ssh -Q ciphers
3des-cbc
aes128-cbc
aes192-cbc
aes256-cbc
aes128-ctr
aes192-ctr
aes256-ctr
aes128-gcm@openssh.com
aes256-gcm@openssh.com
chacha20-poly1305@openssh.com
```

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

git-ab-pre-push - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13390/

Confirmed the post-quantum algorithm is enabled and selected for the connection with 10.1 clients.

**Before**
```
delphix@ip-10-110-206-8:~$ /usr/local/bin/ssh -V
OpenSSH_10.1p1, OpenSSL 3.0.13 30 Jan 2024

delphix@ip-10-110-206-8:~$ /usr/local/bin/ssh delphix@10.110.243.71
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
(delphix@10.110.243.71) Password:

delphix@ip-10-110-206-8:~$ /usr/local/bin/ssh -v delphix@10.110.243.71 2>&1 | grep -i 'kex: algorithm'
debug1: kex: algorithm: curve25519-sha256
(delphix@10.110.243.71) Password:
```

**After post-quantum algorithm support**
```
delphix@ip-10-110-206-8:~$ /usr/local/bin/ssh -v delphix@10.110.199.222 2>&1 | grep -i 'kex: algorithm'
debug1: kex: algorithm: sntrup761x25519-sha512@openssh.com
(delphix@10.110.199.222) Password:

delphix@ip-10-110-206-8:~$ /usr/local/bin/ssh delphix@10.110.199.222
(delphix@10.110.199.222) Password:
```

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
