### PR TITLE
DLPX-97124 Add algif_aead modprobe disable to delphix-platform for CVE-2026-31431 (Copy Fail)

### DIFF
--- a/files/common/etc/modprobe.d/disable-algif_aead.conf
+++ b/files/common/etc/modprobe.d/disable-algif_aead.conf
@@ -1,0 +1,5 @@
+# Disable algif_aead module due to CVE-2026-31431 (AKA copy.fail)
+# This will likely be re-enabled in a subsequent update once an updated
+# kernel has been deployed.
+# Blacklisting the module isn't sufficient, we need to do as below:
+install algif_aead /bin/false


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

CVE-2026-31431 ("Copy Fail") is a critical Linux kernel local privilege
escalation vulnerability (CVSS 7.8) that allows an unprivileged local
user to gain root by corrupting the page cache of setuid binaries via the
`algif_aead` module in the AF_ALG crypto API. It has known public exploits
and is listed in CISA's Known Exploited Vulnerabilities catalog.

Ubuntu released a mitigation via USN-8226-1, which updates the `kmod`
package to version `31+20240202-2ubuntu7.2`. That version's postinst
script creates `/etc/modprobe.d/disable-algif_aead.conf`, blocking the
module from loading. However, engines built from the release branch use an
older apt mirror snapshot (`kmod 31+20240202-2ubuntu7.1`) that predates
USN-8226-1, so the mitigation file is absent and those engines remain
vulnerable.

No upstream kernel fix is available yet for Ubuntu 24.04 LTS — all
Delphix kernel repos (`linux-kernel-aws`, `linux-kernel-generic`,
`linux-kernel-azure`, `linux-kernel-oracle`, `linux-kernel-gcp`) still
carry the vulnerable `crypto/algif_aead.c`.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add `/etc/modprobe.d/disable-algif_aead.conf` directly to
`delphix-platform` under `files/common/etc/modprobe.d/`, containing:

```
install algif_aead /bin/false
```

This ensures the `algif_aead` module is blocked at image build time,
independent of which `kmod` package version is present in the apt mirror
snapshot used during the build. The fix applies to all platforms (the file
lives under `files/common/`) and aligns with the mitigation content
already deployed on develop-branch engines via `kmod 31+20240202-2ubuntu7.2`.

The comment in the file notes that this should be re-evaluated once an
updated kernel containing the upstream fix
(`git.kernel.org/stable/c/a664bf3d603d`) is deployed.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Manually created `/etc/modprobe.d/disable-algif_aead.conf` on a release-branch
engine (`dm-release.dlpxdc.co`, `kmod 31+20240202-2ubuntu7.1`) and confirmed
the module is blocked:

```
root@ip-10-110-250-64:/etc/modprobe.d# sudo modprobe algif_aead
modprobe: ERROR: ../libkmod/libkmod-module.c:1084 command_do() Error running install command '/bin/false' for module algif_aead: retcode 1
modprobe: ERROR: could not insert 'algif_aead': Invalid argument
```

The `install algif_aead /bin/false` rule is correctly intercepting the load
request and returning a non-zero exit code, preventing the module from being
inserted.
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
