### PR TITLE
DLPX-97202 Add esp4/esp6/rxrpc modprobe disable to delphix-platform for CVE-2026-43500 (dirty frag)

### DIFF
--- a/files/common/etc/modprobe.d/dirty-frag.conf
+++ b/files/common/etc/modprobe.d/dirty-frag.conf
@@ -1,0 +1,7 @@
+# Disable esp4, esp6, rxrpc modules due to CVE-2026-43500 (dirty frag)
+# This will likely be re-enabled in a subsequent update once an updated
+# kernel has been deployed.
+# Blacklisting the module isn't sufficient, we need to do as below:
+install esp4 /bin/false
+install esp6 /bin/false
+install rxrpc /bin/false


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

CVE-2026-43500 ("dirty frag") is a critical Linux kernel local privilege
escalation vulnerability (CVSS 7.8, CWE-787) that allows an unprivileged
local user to exploit socket buffers with externally-owned paged fragments
that fall through to in-place decryption paths in the `esp4`, `esp6`, and
`rxrpc` kernel modules.

No upstream kernel fix is available yet for Ubuntu 24.04 LTS — all
Delphix kernel repos still carry the vulnerable code.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Add `/etc/modprobe.d/dirty-frag.conf` directly to `delphix-platform` under
`files/common/etc/modprobe.d/`, containing:

\`\`\`
install esp4 /bin/false
install esp6 /bin/false
install rxrpc /bin/false
\`\`\`

None of these modules are used by the Delphix product. The fix applies to
all platforms (the file lives under `files/common/`) and blocks the modules
at image build time, independent of which `kmod` package version is present.

The comment in the file notes that this should be re-evaluated once an
updated kernel containing the upstream fix is deployed.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

Verified on an engine that has been setup that these modules are not in loaded (only exist in the kernel).
Manually created file `dirty-frag.conf` and tried to load the modules:
```
root@ip-10-110-226-132:/etc/modprobe.d# cat dirty-frag.conf 
install esp4 /bin/false
install esp6 /bin/false
install rxrpc /bin/false
root@ip-10-110-226-132:/etc/modprobe.d# modprobe esp4
modprobe: ERROR: ../libkmod/libkmod-module.c:1084 command_do() Error running install command '/bin/false' for module esp4: retcode 1
modprobe: ERROR: could not insert 'esp4': Invalid argument
root@ip-10-110-226-132:/etc/modprobe.d# modprobe esp6
modprobe: ERROR: ../libkmod/libkmod-module.c:1084 command_do() Error running install command '/bin/false' for module esp6: retcode 1
modprobe: ERROR: could not insert 'esp6': Invalid argument
root@ip-10-110-226-132:/etc/modprobe.d# modprobe rxrpc
modprobe: ERROR: ../libkmod/libkmod-module.c:1084 command_do() Error running install command '/bin/false' for module rxrpc: retcode 1
modprobe: ERROR: could not insert 'rxrpc': Invalid argument
```
</details>