### PR TITLE
DLPX-97204 Upgrade 2026.3→2026.4 fails: dpkg file conflict on /etc/modprobe.d/disable-algif_aead.conf between delphix-platform-aws and kmod 2ubuntu7.2

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -31,7 +31,7 @@ Package: delphix-platform-@@TARGET_PLATFORM@@
 Provides: delphix-platform
 Conflicts: delphix-platform
 Architecture: any
-Replaces: base-files, update-notifier-common
+Replaces: base-files, update-notifier-common, kmod (<< 31+20240202-2ubuntu7.2)
 Depends: ${misc:Depends}, ${delphix:Depends}
 Description: Delphix Appliance Platform
   This package provides the base platform of the Delphix Appliance. It contains

--- a/files/common/etc/modprobe.d/disable-algif_aead.conf
+++ b/files/common/etc/modprobe.d/disable-algif_aead.conf
@@ -1,5 +1,0 @@
-# Disable algif_aead module due to CVE-2026-31431 (AKA copy.fail)
-# This will likely be re-enabled in a subsequent update once an updated
-# kernel has been deployed.
-# Blacklisting the module isn't sufficient, we need to do as below:
-install algif_aead /bin/false


### PR DESCRIPTION
## Summary

`delphix-platform-aws` (release branch) currently ships `/etc/modprobe.d/disable-algif_aead.conf`, added by DLPX-97124 (#559, 2026-05-05). USN-8226-1's `kmod 31+20240202-2ubuntu7.2` ships the same file as a kmod-owned conffile. The two collide at `apt-get install` time:

```
dpkg: error processing archive kmod_31+20240202-2ubuntu7.2_amd64.deb:
  trying to overwrite '/etc/modprobe.d/disable-algif_aead.conf',
  which is also in package delphix-platform-aws 1.0.0-delphix.2026.05.05.22.17
```

This breaks the 2026.3 → 2026.4 `test_upgrade_linux_system` regression with `exception.upgrade.verify.failed` (DLPX-97204, started 2026-05-06).

This PR brings release into parity with develop's resolution: delegate `/etc/modprobe.d/disable-algif_aead.conf` ownership to kmod. The content is byte-identical between the two packages (`install algif_aead /bin/false`), so the mitigation continues uninterrupted.

## Changes

- **Remove** `files/common/etc/modprobe.d/disable-algif_aead.conf`. Because `debian/rules` copies `files/common/*` into every per-cloud `delphix-platform-<cloud>` variant, one deletion covers `aws / azure / esx / gcp / hyperv / kvm / oci`.
- **Append** `kmod (<< 31+20240202-2ubuntu7.2)` to the existing `Replaces:` line in `debian/control.in`, declaring the ownership handoff to dpkg.

## Paired PRs

This PR is one half of a coordinated two-repo fix tracked in OpenSpec change `kmod-usn-8226-1` (delphix/cd-aidlc#47):

1. **THIS PR (release branch)** — drops the conffile from `delphix-platform-aws`. Lands **first** because it's safe in isolation (the file-conflict only manifests once kmod `2ubuntu7.2` is also present on the appliance).
2. **delphix/linux-pkg `projects/DLPX-97147`** — backports `kmod` + `libkmod2` at `31+20240202-2ubuntu7.2` to `packages/misc-debs/config.sh`'s `debs=()`. PR to be opened after this one lands; its CI gates on this fix being on the release branch.

The two combined are validated via `git-ab-pre-push -b "misc-debs delphix-platform" --extra-repo <delphix-platform-feature-branch>` on Jenkins — first run **[#14010](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14010/)** kicked off 2026-05-12.

## Test plan

- [ ] `appliance-build-orchestrator-pre-push` #14010 (in flight) — stage 1 builds `misc-debs` + `delphix-platform`; stage 2 assembles the appliance image; stage 4 re-runs `test_upgrade_linux_system` which is the canonical pass gate for DLPX-97204.
- [ ] On the post-build AMI: `dpkg-query -S /etc/modprobe.d/disable-algif_aead.conf` reports `kmod: ...`, NOT `delphix-platform-aws: ...`.
- [ ] On the post-build AMI: `dpkg-query -W kmod libkmod2` reports `31+20240202-2ubuntu7.2`.

## Validation evidence (pre-build)

Confirmed on freshly-provisioned VMs 2026-05-12 (cf. delphix/cd-aidlc#47's `verification.md`):

- Release VM `psurya-rel-usn8226` (2026.3.0.0, post-push #366):
  - `delphix-platform-aws 1.0.0-delphix.2026.05.11.21.45` (still shipping the file)
  - `dpkg-query -S /etc/modprobe.d/disable-algif_aead.conf` → `delphix-platform-aws: ...`
  - `kmod` at `31+20240202-2ubuntu7.1` (vulnerable; develop ships `2ubuntu7.2`)
- Develop VM `psurya-dev-usn8226` (2026.4.0.0, post-push #4117):
  - `delphix-platform-aws 1.0.0-delphix.2026.05.08.18.02` (no longer ships the file)
  - `dpkg-query -S /etc/modprobe.d/disable-algif_aead.conf` → `kmod: ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)