### PR TITLE
DLPX-86530 CIS: delphix user lockout after failed login attempts

### DIFF
--- a/files/common/usr/share/pam-configs/delphix-faillock-authcheck
+++ b/files/common/usr/share/pam-configs/delphix-faillock-authcheck
@@ -1,0 +1,8 @@
+Name: Delphix faillock failure counter
+Default: yes
+Priority: 0
+Auth-Type: Primary
+Auth:
+        [default=die]   pam_faillock.so authfail audit deny=5 unlock_time=900 onerr=fail
+Auth-Initial:
+        [default=die]   pam_faillock.so authfail audit deny=5 unlock_time=900 onerr=fail

--- a/files/common/usr/share/pam-configs/delphix-faillock-preauth
+++ b/files/common/usr/share/pam-configs/delphix-faillock-preauth
@@ -1,0 +1,13 @@
+Name: Delphix faillock account lockout (preauth)
+Default: yes
+Priority: 1024
+Auth-Type: Primary
+Auth:
+        required        pam_faillock.so preauth silent audit deny=5 unlock_time=900 onerr=fail
+Auth-Initial:
+        required        pam_faillock.so preauth silent audit deny=5 unlock_time=900 onerr=fail
+Account-Type: Primary
+Account:
+        required        pam_faillock.so
+Account-Initial:
+        required        pam_faillock.so

--- a/files/common/usr/share/pam-configs/delphix-pwhistory
+++ b/files/common/usr/share/pam-configs/delphix-pwhistory
@@ -1,0 +1,8 @@
+Name: Delphix password history
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password:
+        requisite       pam_pwhistory.so remember=5 use_authtok
+Password-Initial:
+        requisite       pam_pwhistory.so remember=5 use_authtok

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -504,6 +504,15 @@
     - variant is regex("external-.*")
 
 #
+# CIS hardening (DLPX-86530): account lockout on failed logins via pam_faillock
+# and password-reuse history via pam_pwhistory. The profile files dropped under
+# /usr/share/pam-configs/ are auto-enabled (Default: yes); this call composes
+# them into /etc/pam.d/common-{auth,account,password}. Runs after the CRA
+# enable above so both stacks compose consistently.
+#
+- command: /usr/sbin/pam-auth-update --package
+
+#
 # Increase login timeout to give support more time to interact with CRA via the console.
 #
 - lineinfile:


### PR DESCRIPTION
## Background

CIS hardening — DLPX-86530. The appliance must lock out users after repeated
failed login attempts (\`pam_faillock\` in \`common-auth\` / \`common-account\`)
and reject password reuse (\`pam_pwhistory\` in \`common-password\`). 

## Solution

Three pam-auth-update profiles under \`/usr/share/pam-configs/\` shipped by the
\`delphix-platform\` package, plus a single \`pam-auth-update --package\` ansible
task to compose them in after the CRA enable:

| Profile | Priority | Effect |
|---|---|---|
| \`delphix-faillock-preauth\` | 1024 | \`auth required pam_faillock.so preauth …\` at top of auth; \`account required pam_faillock.so\` (also resets tally on success) |
| \`delphix-faillock-authcheck\` | 0 | \`auth [default=die] pam_faillock.so authfail …\` at bottom of auth |
| \`delphix-pwhistory\` | 1024 | \`password requisite pam_pwhistory.so remember=5 use_authtok\` before pam_unix |

Faillock parameters: \`deny=5 unlock_time=900 onerr=fail audit silent\`.
Pwhistory: \`remember=5\`.

All three profiles set \`Default: yes\` so they auto-enable on install.
pam-auth-update recalculates the \`success=N\` jumps and composes faillock
around whichever Primary auth module is active (\`unix\` on internal,
\`challenge-response\` on external), so the same change works for all variants.
The \`account required pam_faillock.so\` line handles counter reset on
successful auth — no separate \`authsucc\` is needed.


## Testing Done

- [ ] \`appliance-build-orchestrator/pre-push\` green on a build for an
      internal variant
- [ ] \`appliance-build-orchestrator/pre-push\` green on a build for an
      external variant
- [ ] Smoke test on built engine:
  - 5 failed \`delphix\` ssh logins → 6th attempt rejected even with right
    password
  - Wait \`unlock_time=900s\` → next login succeeds and tally cleared
  - Change \`delphix\` password to a previously-used one → rejected by
    pwhistory
  - Successful login mid-streak → tally cleared by \`account required
    pam_faillock.so\`
- [ ] Verify \`/etc/pam.d/common-auth\` composition after CRA toggle on an
      external variant (faillock lines present, ordering correct)