### PR TITLE
DLPX-86523 CIS: mount appliance user home at /home

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2023 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,17 +15,6 @@
 #
 
 ---
-#
-# We use a non-standard directory for the appliance user's home
-# directory. As a result, we have to explicitly create the "base
-# directory" here, rather than rely on Ansible's user module to create
-# it below; otherwise that task will fail.
-#
-- file:
-    path: /export/home
-    state: directory
-    mode: 0755
-
 - user:
     name: delphix
     uid: 65433
@@ -35,7 +24,7 @@
     shell: /bin/bash
     create_home: yes
     comment: Delphix User
-    home: /export/home/delphix
+    home: /home/delphix
 
 #
 # In order for this locale to be used (e.g. by virtualization) we need
@@ -637,7 +626,7 @@
 
 - name: Source bash completion
   blockinfile:
-    dest: "/export/home/delphix/.bashrc"
+    dest: "/home/delphix/.bashrc"
     block: |
       . /etc/bash_completion.d/systemctl
       . /etc/bash_completion.d/zfs


### PR DESCRIPTION
## Problem

CIS hardening requires the home filesystem to be mounted at the standard
`/home` location. Today the home dataset is mounted at `/export/home`,
which causes the following CIS report failures:

- (1.45) 7402 Status of the `/home` partition in `/etc/fstab`
- (1.46) 13248 Status of mount partition `/home` using the `mount` command
- (1.47) 7403 Status of the `nodev` mount option for `/home` in `/etc/fstab`
- (1.48) 14601 Status of the `nodev` option for `/home` using `mount`

## Solution

Move the appliance `delphix` user's home directory from `/export/home/delphix`
to `/home/delphix` by updating the Ansible tasks to reference `/home`.

This is the `delphix-platform` half of a flag-day change. The dataset mount,
the `/export/home` -> `/home` backward-compat symlink, and the `/home` fstab
`nodev,nosuid` hardening are all handled on the appliance-build side:

- appliance-build: https://github.com/delphix/appliance-build/pull/869

Because appliance-build now owns the `/home` mount, the previous explicit
base-directory creation task (and its now-stale comment about a "non-standard"
home location) is dropped — `/home` is a standard mountpoint that already
exists when these tasks run, so `create_home: yes` populates `/home/delphix`
on its own.

> **Flag day:** this PR and appliance-build #869 must land together, since
> this change assumes `/home` is mounted at apply time.

## Testing Done

Refer to the testing section in the appliance-build counterpart:
https://github.com/delphix/appliance-build/pull/869