### PR TITLE
TOOL-30723 select the buildserver swap device by property, not by name

### DIFF
--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/buildserver.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/buildserver.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Delphix
+# Copyright 2022, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,16 +39,120 @@
 # We've hit build failures when swap space is not available, so we've
 # opted to automatically configure swap space here.
 #
-# This is a bit awkward, but we've hardcoded the device we're using for
-# swap here, based on the assumption that the Delphix buildserver will
-# only be used on AWS, and will have 3 "data" disks available like
-# normal internal Delphix DCenter systems.
+# We pick the device to use by property rather than by name. This task
+# used to hardcode /dev/nvme1n1, on the assumption that the buildserver
+# would only run on AWS and would have 3 "data" disks available like
+# normal internal Delphix DCenter systems. The disks are still there,
+# but AWS does not guarantee a stable mapping between EBS volumes and
+# NVMe device names across boots, so /dev/nvme1n1 is sometimes the root
+# pool disk, which leaves the buildserver with no swap at all; see
+# TOOL-30723.
 #
 # Additionally, we're not using a file on the root filesystem, as we
 # assume the root filesystem is on ZFS, and swap on ZFS can lead to
 # deadlocks; see: https://github.com/openzfs/zfs/issues/7734.
 #
-- shell: |
-    mkswap /dev/nvme1n1
-    swapon /dev/nvme1n1
+- shell:
+    cmd: |
+      set -o errexit
+      set -o pipefail
+
+      #
+      # A candidate must be a whole disk, in the size range we expect the
+      # DCenter "data" disks to be in, and must show no sign of being in use.
+      # If we cannot find such a disk we fail rather than guess, since writing
+      # a swap header onto the wrong disk would be destructive.
+      #
+      # Note that Ansible templates this through Jinja before running it, so
+      # none of Jinja's opening delimiters can appear anywhere below, not even
+      # inside a comment. That rules out the array-length form of parameter
+      # expansion (dollar, brace, hash), which is why the test for an empty
+      # array below goes through "${rejected[*]}" instead.
+      #
+      swapdev=
+      declare -a rejected=()
+
+      while read -r name size type; do
+          [[ "$type" == "disk" ]] || continue
+
+          #
+          # Zvols are reported as disks, and an unused one has neither a
+          # signature nor holders, so none of the checks below would
+          # exclude it.
+          #
+          if [[ "$name" == zd* ]]; then
+              rejected+=("$name: zvol")
+              continue
+          fi
+
+          if ((size <= 2000000000 || size >= 10000000000)); then
+              rejected+=("$name: size $size outside expected data disk range")
+              continue
+          fi
+
+          #
+          # lsblk reports partitions and holders as dependents of the
+          # disk, so a lone line means the disk has neither. This is what
+          # excludes the root pool disk, which always carries partitions.
+          #
+          if [[ "$(lsblk -no NAME "/dev/$name" | wc -l)" -ne 1 ]]; then
+              rejected+=("$name: has partitions or holders")
+              continue
+          fi
+
+          if [[ -n "$(ls -A "/sys/block/$name/holders" 2>/dev/null)" ]]; then
+              rejected+=("$name: has holders")
+              continue
+          fi
+
+          #
+          # Anything carrying a signature is in use by something, with the
+          # exception of a swap signature that we wrote on an earlier run.
+          #
+          fstype=$(lsblk -dno FSTYPE "/dev/$name")
+          if [[ -n "$fstype" && "$fstype" != "swap" ]]; then
+              rejected+=("$name: has $fstype signature")
+              continue
+          fi
+
+          swapdev="/dev/$name"
+          break
+      done < <(lsblk -dnbo NAME,SIZE,TYPE | sort)
+
+      if [[ -z "$swapdev" ]]; then
+          echo "Failed to find a device to use for swap." >&2
+          if [[ -n "${rejected[*]}" ]]; then
+              printf '  rejected %s\n' "${rejected[@]}" >&2
+          fi
+          lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT >&2
+          exit 1
+      fi
+
+      #
+      # Only write a new swap header if the disk doesn't already carry one.
+      # Running mkswap again would generate a fresh UUID, which would leave
+      # the fstab entry written below pointing at a UUID that no longer
+      # exists, and add a second entry alongside it.
+      #
+      if [[ "$(lsblk -dno FSTYPE "$swapdev")" != "swap" ]]; then
+          mkswap "$swapdev"
+      fi
+      swapon "$swapdev"
+
+      #
+      # "swapon" is not persistent, and this playbook only runs on the first
+      # boot (see the "ansible-done" handling in the "apply" script), so
+      # without an fstab entry every subsequent boot would come up with no
+      # swap at all. "nofail" keeps a clone that comes up without this disk
+      # from holding up the boot.
+      #
+      uuid=$(blkid -s UUID -o value "$swapdev")
+      if [[ -z "$uuid" ]]; then
+          echo "Failed to determine the UUID of $swapdev." >&2
+          exit 1
+      fi
+      if ! grep -q "^UUID=$uuid " /etc/fstab; then
+          echo "UUID=$uuid none swap sw,nofail 0 0" >>/etc/fstab
+      fi
+    executable: /bin/bash
   when: show.stdout == ""

--- a/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
+++ b/files/common/var/lib/delphix-platform/ansible/10-delphix-platform/roles/delphix-platform/tasks/main.yml
@@ -611,11 +611,6 @@
     path: "/etc/apt/sources.list.d/ubuntu-esm-infra.list"
     state: absent
 
-- include_tasks: buildserver.yml
-  when:
-    - variant == "internal-buildserver"
-    - not ansible_is_chroot
-
 - name: Add systemctl bash completion
   copy:
     dest: "/etc/bash_completion.d/systemctl"
@@ -675,3 +670,14 @@
     path: /etc/environment
     state: absent
     regexp: '^\s*PATH\s*='
+
+#
+# This is deliberately the last thing in this file. The buildserver
+# tasks configure swap, and that fails the playbook if no suitable
+# device can be found; we don't want such a failure to skip any of the
+# configuration above, as it did before TOOL-30723.
+#
+- include_tasks: buildserver.yml
+  when:
+    - variant == "internal-buildserver"
+    - not ansible_is_chroot


### PR DESCRIPTION
## Problem

`buildserver.yml` configures swap on a hardcoded `/dev/nvme1n1`. AWS doesn't
guarantee a stable mapping between EBS volumes and NVMe device names across
boots, so `/dev/nvme1n1` is whichever disk happened to enumerate second, and on
some boots that is the 512G root pool disk rather than one of the 8G data disks.

Two VMs cloned from the same image on the same day, same instance size, drew
different layouts:

| VM | root pool | `nvme1n1` | swap | delphix-platform |
| --- | --- | --- | --- | --- |
| `pre-push-3548` | `nvme1n1p1` | root disk | none | **failed** |
| `pre-push-3553` | `nvme0n1p1` | 8G data disk | 8G, 585M in use | active |

When it lands on the root disk, ZFS holds the device open, so the task fails;
e.g.

```
mkswap: cannot open /dev/nvme1n1: Device or resource busy
swapon: /dev/nvme1n1: read swap header failed
```

Three things follow, in increasing order of seriousness:

1. No swap for the life of the VM. `c5.large` (2 vCPU / 3.2 GiB usable) is the
   default for linux-pkg `build-package` jobs, and without swap a memory-hungry
   link is OOM-killed; `ld` was holding only ~2 GB when it died.
2. The whole playbook aborts. `apply` runs `exit 1` on a failed playbook, so
   `delphix-platform.service` fails and `ansible-done` is never written. Every
   task ordered after this one is skipped, so the buildserver comes up
   misconfigured in ways beyond swap.
3. Latent data loss. Nothing checks what the device is before `mkswap` runs on
   it. The only thing that prevented the root pool being overwritten is that
   ZFS held the device open. A boot where the pool is not yet imported has no
   such protection.

Separately, `swapon` is not persistent and this playbook only runs on the first
boot (see the `ansible-done` handling in `apply`), so even a buildserver that
does get swap comes up without it on every subsequent boot.

## Solution

The solution taken in this PR is to select the device by property rather than by
name. A candidate must be a whole disk in the size range we expect the DCenter
data disks to be in, and must show no sign of being in use:

- size strictly between 2000000000 and 10000000000 bytes (the same window the
  Jenkins `enable-swap.sh` helper uses)
- not a zvol (an unused zvol has neither a signature nor holders, so nothing
  else would exclude it)
- no partitions and no holders
- no filesystem or pool signature, except a `swap` signature left by an earlier
  run

The size and partition checks each independently reject the disk that broke
`pre-push-3548`, so one of them regressing doesn't reintroduce the bug. A wrong
guess is now a loud failure rather than a destructive write, and the reason each
candidate was rejected is logged; e.g.

```
Failed to find a device to use for swap.
  rejected nvme0n1: size 549755813888 outside expected data disk range
  rejected nvme1n1: has ext4 signature
  rejected nvme2n1: has ext4 signature
  rejected nvme3n1: has partitions or holders
```

Failing to find a device still fails the playbook, since a buildserver with no
swap should be obvious immediately rather than surface as a mystery OOM partway
through a build. To keep that from taking the rest of the configuration with it,
the `include_tasks: buildserver.yml` block moves to the end of `main.yml`, where
nothing is ordered after it to be skipped.

The selected device also gets an `/etc/fstab` entry, so swap survives a reboot.
`nofail` is there so a clone that comes up without that disk isn't held up at
boot. An existing swap signature is reused rather than re-`mkswap`ed, since a
fresh `mkswap` generates a new UUID and would leave the fstab entry pointing at
a UUID that no longer exists, plus a second entry alongside it.

Two things worth flagging for review, both about embedding bash in a `shell:`
task, and neither of which shows up until a buildserver actually boots (at build
time the include is skipped under `ansible_is_chroot`, so the file isn't even
parsed):

- Ansible splits the free-form `shell:` value on quotes, so an apostrophe in a
  comment ("can't") fails the task with `failed at splitting arguments, either
  an unbalanced jinja2 block or quotes`. The task uses the `cmd:` dict form,
  which isn't subject to that splitting.
- Ansible templates the value through Jinja, so `{{`, `{%` and `{#` can't
  appear anywhere in the script, not even in a comment. That rules out
  `${#array[@]}`, which is why the empty-array test goes through
  `${rejected[*]}`. There's a comment in the task recording this.

## Testing Done

`ab-pre-push` (internal-buildserver / aws): https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14720/

Verified on a `COMPUTE_LARGE` buildserver VM cloned from
`dlpx-internal-buildserver-develop`, which drew the layout where `nvme0n1` is
the 512G root pool disk and `nvme1n1`-`nvme3n1` are the 8G data disks.

Baseline, before the change, reproducing the persistence half of the bug: swap
active on `/dev/nvme1n1` but no fstab entry at all.

With the change, on a clean data disk:

```
$ swapon --show
NAME         TYPE      SIZE USED PRIO
/dev/nvme1n1 partition   8G   0B   -2
$ grep 'none swap' /etc/fstab
UUID=e6e566d5-614d-4e0e-aa9c-170f1e30b5f8 none swap sw,nofail 0 0
```

Confirmed across a reboot, which is what the old code never had. systemd picks
the entry up out of fstab:

```
$ swapon --show=NAME,SIZE --noheadings
/dev/nvme1n1   8G
$ systemctl list-units --type=swap --all --no-legend | grep by.2duuid
dev-disk-by\x2duuid-e6e566d5\x2d614d\x2d4e0e\x2daa9c\x2d170f1e30b5f8.swap loaded active active
```

Re-running with the swap signature left in place reuses the disk and keeps the
UUID stable, with exactly one fstab entry (this is what caught the re-`mkswap`
bug described above).

Rejection and failure paths, driven by making every in-window disk ineligible
(ext4 on two of them, a partition on the third): the playbook fails, no swap is
configured, no fstab line is written, and nothing is written to any disk. That
run is the `rejected ...` output quoted in the Solution section above;
`rejected nvme3n1: has partitions or holders` is the same check that rejects the
root pool disk in the `pre-push-3548` layout.

Confirmed the tasks now ordered after the include still take effect, since
those are the ones that got skipped on `pre-push-3548`:

```
$ findmnt -no OPTIONS /dev/shm
rw,nosuid,nodev,noexec,inode64
$ grep -h 'PATH DEFAULT' /etc/security/pam_env.conf
PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
$ systemctl is-active nullmailer
inactive
```

`delphix-platform` came up `active` with `ansible-done` written and no failed
units, so the full playbook completed with the reordered `main.yml`.

The selection logic was developed against a harness that stubs `lsblk` and
covers 13 cases, including both the `pre-push-3548` and control layouts, the
zvol and partitioned-disk rejections, and fstab idempotency. Since the logic
lives inline in the task rather than in a shipped script, the harness isn't part
of this repo; note also that CI's `shellcheck`/`shfmt` don't see bash embedded
in YAML, so the script was shellchecked by extracting it back out of the parsed
YAML.
