### PR TITLE
CP-13591 Gate sshd on /etc/ssh/sshd_disable for the engine disable-SSH feature

### DIFF
--- a/files/common/lib/systemd/system/ssh.service.d/override.conf
+++ b/files/common/lib/systemd/system/ssh.service.d/override.conf
@@ -13,3 +13,13 @@
 DefaultDependencies=no
 After=network-online.target
 Wants=network-online.target
+
+#
+# Gate sshd on the absence of /etc/ssh/sshd_disable so the engine-level
+# "disable SSH" feature can make sshd unstartable. When the marker exists,
+# systemd skips starting ssh.service; ssh.socket is Accept=no and activates
+# ssh.service, so it has nothing to hand off to and SSH is fully disabled
+# without masking or touching the socket. The marker lives in /etc/ssh so it
+# persists across upgrade alongside the host keys.
+#
+ConditionPathExists=!/etc/ssh/sshd_disable


### PR DESCRIPTION
## Problem

The engine-level "disable SSH" feature (appliance CP-13590 / PR delphix/dlpx-app-gate#4686, customer escalation PPM-1651) needs to make sshd truly unstartable when an administrator disables SSH. There was no supported way to gate ssh startup on an engine-managed marker.

## Solution

Add `ConditionPathExists=!/etc/ssh/sshd_disable` to the `ssh.service` drop-in (`files/common/lib/systemd/system/ssh.service.d/override.conf`). When the appliance creates that marker (disable SSH), systemd skips starting `ssh.service` — even a manual `systemctl start` is a no-op — so sshd is truly unstartable; when the appliance removes the marker (enable SSH), `ssh.service` starts normally. `ssh.socket` is `Accept=no` and activates `ssh.service`, so gating the service alone is sufficient: no mask, and no change to `ssh.socket`. The marker lives in `/etc/ssh`, which persists across upgrade alongside the host keys, so the disabled state survives upgrade. This is the idiomatic mechanism — stock Ubuntu `ssh.service` already ships `ConditionPathExists=!/etc/ssh/sshd_not_to_be_run`.

## Testing Done

Validated on a develop engine: with the drop-in in place, creating `/etc/ssh/sshd_disable` makes `systemctl start ssh.service` a no-op (unit stays `inactive`), and a live SSH handshake gets `Connection reset` (the socket activates the condition-blocked service). Removing the marker and starting `ssh.service` restores SSH. Driven end-to-end via the appliance `enableSsh`/`disableSsh` REST API.

Verified the brand-new-image case directly (drop-in present, no marker): `ssh.service`'s `ConditionResult` is `yes`, sshd starts and serves connections normally, and the engine boots healthy — the drop-in is inert until the marker exists, and an unmet `Condition*` cleanly *skips* the unit (never fails boot).

Combined appliance + delphix-platform pre-push build/test — `appliance-build-orchestrator-pre-push` #14805 (this branch + app-gate CP-13590): https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14805/ — **fully green**. All stages SUCCESS: `linux-pkg` package build, `appliance-build`, `ami-snapshots`, `dx-integration-tests` #36595, and `upgrade-testing` #4637. Fresh images carrying this drop-in build, snapshot, boot, upgrade, and pass the full integration suite with SSH working by default.

(An earlier run #14803 had hit a known-flaky `test_upgrade_linux_system` environmental failure — `sudo unpack-image` returning -1 then the target engine going unreachable — unrelated to this change: no `ConditionPathExists`/`sshd_disable`/`ssh.service` involvement, SSH enabled/working throughout, and the same test fails identically on runs without this change. It passed cleanly in #14805 with no change to that path.)

## Dependency

Pairs with appliance PR delphix/dlpx-app-gate#4686 (CP-13590); neither is functional alone.