### PR TITLE
DLPX-95672 order sb-enroll before cloud-init so its reboot cannot interrupt it

### DIFF
--- a/files/common/lib/systemd/system/delphix-sb-enroll.service
+++ b/files/common/lib/systemd/system/delphix-sb-enroll.service
@@ -6,10 +6,46 @@ Before=delphix-platform.service
 After=var-delphix.mount local-fs.target
 ConditionPathExists=/var/delphix/server/sb_certs/
 
+#
+# This unit ends by rebooting the appliance, so it must finish before
+# anything that would be left half-done by that reboot. Ordering it
+# before "cloud-init.service" holds back the whole cloud-init sequence
+# on AWS: the Ec2 datasource is "dsmode=net", so "cloud_init_modules"
+# runs in that stage, and it is itself ordered before
+# "cloud-config.target", which gates the "cloud-config" and
+# "cloud-final" stages.
+#
+# Without this, the reboot lands in the middle of the network stage
+# while it is generating the SSH host keys. Cloud-init writes each
+# module's "once-per-instance" semaphore before running the module, so
+# the interrupted module is skipped on every subsequent boot rather
+# than retried, and the appliance is left permanently missing
+# "/etc/ssh/ssh_host_rsa_key" (DLPX-95672). RSA is the one that loses
+# because it is generated first and takes ~100x longer than the ecdsa
+# and ed25519 keys that follow it.
+#
+# This covers the network stage only. A "dsmode=local" datasource runs
+# "cloud_init_modules" in "cloud-init-local.service" instead, so
+# teaching sb-enroll-efivars.sh about a cloud whose datasource is
+# local-mode means ordering before that unit as well.
+#
+Before=cloud-init.service
+
 [Service]
 Type=oneshot
 Environment=SB_AUTH_DIR=/var/delphix/server/sb_certs/
 ExecStart=/var/lib/delphix-sb-enroll/sb-enroll-efivars.sh
+#
+# Bound the blast radius of the ordering above. "cloud-init.service" is
+# itself "Before=sysinit.target" and "Before=network-online.target", and
+# sshd waits on "network-online.target", so a hang in here would leave
+# the appliance neither booted nor reachable -- and "Type=oneshot"
+# otherwise defaults to an infinite start timeout. Enrollment is three
+# EFI SetVariable() calls, so this is orders of magnitude more than it
+# needs. A timeout (like any other failure) only ever releases the
+# ordering, since nothing "Requires=" this unit.
+#
+TimeoutStartSec=120
 # Prevent accidental re-runs the same boot unless you change the inputs
 RemainAfterExit=no
 


### PR DESCRIPTION
## Problem

`delphix-sb-enroll.service` enrolls the Secure Boot PK/KEK/db on the first boot of an AWS instance and ends by rebooting the appliance with `init 6`. It carries `DefaultDependencies=no` and orders itself only `After=var-delphix.mount local-fs.target` / `Before=delphix-platform.service`, so there is no ordering edge of any kind between it and cloud-init. The two run concurrently, and the reboot lands in the middle of cloud-init's network stage while `cc_ssh` is generating the SSH host keys:

```
16:18:37.990895 systemd[1]: Starting delphix-sb-enroll.service - Enroll Secure Boot variables ...
16:18:49.631962 systemd[1]: Starting cloud-init.service - Cloud-init: Network Stage...
16:18:51.496756 sb-enroll-efivars.sh[511]: [sb-enroll] PK: update submitted
16:18:51.497540 sb-enroll-efivars.sh[511]: [sb-enroll] Rebooting...
16:18:52.318374 systemd[1]: cloud-init.service: Main process exited, code=exited, status=120/n/a
```

The SIGTERM from that shutdown runs cloud-init's `signal_handler._handle_exit`, whose first statement is `sys.stderr.write()` on an already-torn-down pipe. It raises `BrokenPipeError` before reaching the `sys.exit(0)` on the next line, the exception unwinds out of `subprocess.communicate()`, and `cc_ssh` catches it, logs a warning, and moves on to the next key type:

```
16:18:50,364 - subp.py[DEBUG]: Running command ['ssh-keygen', '-t', 'rsa', ...]
16:18:51,861 - performance.py[DEBUG]: Running ['ssh-keygen', '-t', 'rsa', ...] took 1.496 seconds
16:18:51,861 - log_util.py[WARNING]: Failed generating key type rsa to file /etc/ssh/ssh_host_rsa_key
    BrokenPipeError: [Errno 32] Broken pipe
16:18:51,876 - performance.py[DEBUG]: Running ['ssh-keygen', '-t', 'ecdsa', ...] took 0.011 seconds
```

RSA is the only casualty because `GENERATE_KEY_NAMES = ["rsa", "ecdsa", "ed25519"]` puts it first and it takes ~100x longer than the other two, which finish in ~11ms and ~25ms before systemd gets around to killing the cgroup.

It is never repaired afterwards. `cloudinit/helpers.py:run()` enters the module's `once-per-instance` semaphore *before* calling the module functor, with `clear_on_fail` defaulting to False, so the semaphore is already on disk when the failure happens and the boot after the reboot logs `config-ssh already ran (freq=once-per-instance)` and skips the module outright. `ssh_deletekeys: false` in `91-delphix-platform.cfg` means nothing clears the surviving keys to force a regeneration, and openssh 9.6 on 24.04 ships `ssh.service` with only `ExecStartPre=/usr/sbin/sshd -t` — no `sshd_check_keys` hook — so sshd starts happily with one of its three configured host keys missing. Cloud-init calls the boot clean throughout (`Ran 3 modules with 0 failures`), so nothing surfaces until something reads the file.

The engine is then permanently missing `/etc/ssh/ssh_host_rsa_key{,.pub}`, which is DLPX-95672 and everything downstream of it: repave prepare fails `RepaveReadFileFailed` (DLPX-98122), `GET /delphix/system` returns an empty `sshPublicKey` and logs `Public key file /etc/ssh/ssh_host_rsa_key.pub is missing` on every call (DLPX-95329, which blocked a customer POV as ESCL-5662), and blackbox `test_system_info_api` fails on `cat /etc/ssh/ssh_host_rsa_key.pub` (DLPX-95724, most recently blackbox-self-service #228572).

The runway from cloud-init's network stage starting to `init 6` measured 1.87s / 1.62s / 1.09s across three clones, against the ~2.2s the RSA keygen needs. That sub-second margin is why this presents as intermittent across image builds rather than as a flat rule.

## Solution

The solution is to give `delphix-sb-enroll.service` a `Before=cloud-init.service` edge, so its reboot cannot land inside any cloud-init module. `cloud-init.service` is the network stage that runs `cloud_init_modules` (including `ssh`), and it is itself ordered `Before=cloud-config.target`, which gates the `cloud-config` and `cloud-final` stages. On AWS that holds back the whole module pipeline, since the Ec2 datasource is `dsmode=net` and so `cloud_init_modules` runs in the network stage. On a first boot the reboot now happens before any of it has started, and on the boot after that Secure Boot is already enabled, the script exits 0 in ~200ms, and cloud-init runs to completion normally.

`Before=` rather than `After=` matters here. Anchoring `After=cloud-init.service` would only relocate the hazard: sb-enroll takes ~13.5s (three `efi-updatevar` calls), so starting it when the network stage finishes puts the reboot inside `cloud-config`/`cloud-final` instead, whose modules include `grub-dpkg`, `package-update-upgrade-install`, and `scripts-per-once`/`scripts-per-instance` — the last two carrying the identical once-per-instance semaphore that never retries, and the first two being considerably worse things to interrupt than a host key. Anchoring on `cloud-final.service` is worse still: it is `After=multi-user.target sysinit.target basic.target`, so because sb-enroll is `Before=delphix-platform.service` it drags the whole Delphix stack past `multi-user.target` (measured: `delphix-platform` moving from ~5.5s *before* `multi-user.target` to ~0.8s *after* `cloud-final`) — a permanent every-boot reordering of appliance startup bought to fix a first-boot-only race.

The edge covers the network stage only. A `dsmode=local` datasource runs `cloud_init_modules` in `cloud-init-local.service` instead, so teaching `sb-enroll-efivars.sh` about a cloud whose datasource is local-mode means ordering before that unit too. That is recorded as a comment in the unit rather than a second `Before=`, since `cloud-init-local.service` is `DefaultDependencies=no` and is not `After=local-fs.target`; forcing it behind sb-enroll (which is `After=var-delphix.mount local-fs.target`) would reorder early boot more broadly, with cycle risk, for a path nothing exercises today.

`TimeoutStartSec=120` comes along with the ordering. `cloud-init.service` is itself `Before=sysinit.target` and `Before=network-online.target`, and `ssh.service` waits on `network-online.target`, so sb-enroll now sits in front of sshd. With `Type=oneshot` defaulting to an infinite start timeout, a hang in `efi-updatevar` would leave the appliance neither booted nor reachable. Enrollment is three EFI `SetVariable()` calls, so 120s is orders of magnitude more than it needs, and a timeout (like any other failure) only releases the ordering, since nothing `Requires=` this unit.

Note this does not repair engines that are already missing the key; `ssh-keygen -A` creates only what is absent and is safe to run live, but a self-healing unit is deliberately left out of this change.

## Testing Done

Reproduced the defect 4/4 on freshly cloned AWS engines (`dlpx-psurya-develop` / `ami-0bc7975017a985c09`, 2026.5.0.0 build 10098) before changing anything — each came up with only ecdsa and ed25519 host keys, two boots ~22s apart, `Failed generating key type rsa` on the first and `config-ssh already ran` on the second.

Validated the ordering directive itself as a runtime drop-in on a live engine, A/B against the two rejected alternatives, one reboot each. With `Before=cloud-init.service`:

```
16:56:33.632 Starting delphix-sb-enroll.service ...
16:56:33.847 Finished delphix-sb-enroll.service ...
16:56:41.875 Starting cloud-init.service - Cloud-init: Network Stage...
16:56:42.715 Finished cloud-init.service - Cloud-init: Network Stage.
16:56:43.249 Starting delphix-platform.service ...
16:56:50.396 Reached target multi-user.target
```

sb-enroll completes well before the network stage starts, `delphix-platform` still starts before `multi-user.target` (so the baseline boot shape is preserved), `cloud-init status` reports `done`, and all host keys are intact. No ordering cycle in any of the three configurations tested: `systemd-analyze verify` is clean and no boot logged `Found ordering cycle` / `Breaking ordering cycle`.

Confirmed from the first-boot cloud-init log that `cloud-init-local.service`, which still runs concurrently with sb-enroll, executes no config modules at all — every `once-per-instance` module (`seed_random`, `ssh`) runs in the network stage — so the remaining concurrency is limited to datasource and network detection, which demonstrably re-derives after a reboot (`cache invalid in datasource` on the second boot of the original engine).

`appliance-build-orchestrator-pre-push` #14862 (`-p aws --no-tests`) built `cd3e664`, the pre-review revision of this branch, and came back FAILURE. That failure is not from anything in the change: every named stage of the `appliance-build-stage0` child is SUCCESS, including `Build Artifacts` and `Copy Input S3 Artifacts`, and the run died in teardown with `hudson.remoting TimeoutException: Ping ... hasn't completed` while scheduling `dcenter-suspend`, i.e. a lost agent connection.

The PR's own `jenkinsci/appliance-build-orchestrator` pre-push check is running against `a5ceb15` now: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/github/job/delphix/job/delphix-platform/job/appliance-build-orchestrator/job/pre-push/811/. I'll clone fresh engines off the resulting image, confirm all three host keys are generated on first boot, and update here with the result. The blackbox suite is not the interesting signal for this one, since the defect only manifests on a fresh instance's very first boot.

`TimeoutStartSec=` is not yet re-verified on a booted engine. `systemd-analyze verify` is clean on the unit and the value parses (a bogus value there is reported as `Failed to parse TimeoutStartSec= parameter, ignoring`), but the A/B boot runs above predate it.

## Risk

`efi-updatevar` has no timeout of its own, and sb-enroll now gates cloud-init, hence `sysinit.target` and sshd. That is bounded with `TimeoutStartSec=120` rather than left open. What remains is that a timeout now costs a first boot 120s before enrollment gives up, against an unbounded hang today.

Ordering-only is deliberate. Nothing `Requires=` sb-enroll, so a condition-skipped or failing enroll still releases cloud-init; that matters on the platforms where the script `exit 0`s immediately, and given DLPX-95335 (this unit failing outright on OCI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

